### PR TITLE
Item 엔티티 Spec 엔티티 구현 완료

### DIFF
--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
@@ -1,0 +1,38 @@
+package project.main.webstore.domain.item.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.main.webstore.domain.item.enums.Category;
+import project.main.webstore.domain.item.enums.ItemStatus;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = "id")})
+@NoArgsConstructor(access = PROTECTED)
+public class Item {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+    private String name;
+    private int itemCount;
+    private int price;
+    private Category category;
+
+    @Lob
+    private String description;
+    //상세 정보
+
+    @Enumerated
+    private ItemStatus itemStatus = ItemStatus.ON_STACK;
+
+    @OneToMany(mappedBy = "item")
+    private List<Spec> specList = new ArrayList<>();
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Spec.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Spec.java
@@ -1,0 +1,25 @@
+package project.main.webstore.domain.item.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Spec {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+    private String name;
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "ITEM_ID")
+    private Item item;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/enums/Category.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/enums/Category.java
@@ -1,0 +1,11 @@
+package project.main.webstore.domain.item.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum Category {
+    COMPUTER,MONITOR
+    ;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/enums/ItemStatus.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/enums/ItemStatus.java
@@ -1,0 +1,11 @@
+package project.main.webstore.domain.item.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ItemStatus {
+    SOLD_OUT, ON_STACK
+    ;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/users/entity/User.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/users/entity/User.java
@@ -21,6 +21,7 @@ import static lombok.AccessLevel.PROTECTED;
 public class User extends Auditable {
     @Id
     @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false)
     private Long id;
     private String nickName;
     private String password;


### PR DESCRIPTION
# 작업 내용
1. Item 엔티티 구현
2. Spec 엔티티 구현

# 작업 회고
Item 엔티티 구현 중 서로 상이한 스펙을 가지고 있는 카테고리별 제품을 어떻게 구현해야되나 많은 생각을 했었다.

## 고민했던 내용
1. JSON으로 집어 넣기
    * 조회에서 문제가 발생할 수 있다.
2. String 값으로 모든 값을 받기
    * 표 형식으로 사용 등에서 문제가 생길 수 있다고 판단했다.
3. DB를 테이블 하나하나 만들어 주기
    * 일단 이렇게 만들면 새로운 카테고리의 제품을 추가할 떄 사용자가 직접 추가 할 수 없다.

결론
스펙 테이블을 따로 만들어서 해당 테이블과 Item 테이블을 연결 시켜줬다.
