### PR TITLE
[feat] OrderHistoryEntity 구현

### DIFF
--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/Cart.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/Cart.java
@@ -4,19 +4,15 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 
-import static javax.persistence.GenerationType.IDENTITY;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Cart {
     @Id
-    @GeneratedValue(strategy = IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(updatable = false)
     private long id;
     private int count;

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/CartItem.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/CartItem.java
@@ -3,17 +3,14 @@ package project.main.webstore.domain.cart.entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Getter
 @NoArgsConstructor
 @Entity
 public class CartItem {
     @Id
-    @GeneratedValue
-    @Column(unique = true, updatable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
     private long id;
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/entity/OrderHistory.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/entity/OrderHistory.java
@@ -1,0 +1,32 @@
+package project.main.webstore.domain.orderHistory.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.orderHistory.enums.OrderStatus;
+import project.main.webstore.valueObject.Address;
+
+import javax.persistence.*;
+
+import static javax.persistence.EnumType.STRING;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class OrderHistory extends Auditable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private long id;
+    private String orderNumber;
+    private long deliveryPrice;
+    private long totalPrice;
+    private long discountedPrice;
+
+    @Embedded
+    private Address address;
+
+    @Enumerated(STRING)
+    private OrderStatus orderStatus = OrderStatus.INCART;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/enums/OrderStatus.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/enums/OrderStatus.java
@@ -1,0 +1,12 @@
+package project.main.webstore.domain.orderHistory.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OrderStatus {
+    INCART("장바구니"), BEFORE("입금 전"), PAID("결제 완료"), SHIPPING("배송 중"), COMPLETE("배송 완로"), PURCHASE("구매 확정"), CANCEL("구매 취소");
+
+    private String description;
+}


### PR DESCRIPTION
# 작업 내용
1. OrderHistory 엔티티 구현

# 작업 회고
주문 내역과 관련된 주문의 상태를 표현하는 방법을 고민하다가 enum 사용하여 상태 설정

# 작업 예정
타 엔티티 작성 완료 시, 연관 관계 매핑
