### PR TITLE
나머지 엔티티 구현 완료

### DIFF
--- a/BE/backend/src/main/java/project/main/webstore/domain/answer/entity/Answer.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/answer/entity/Answer.java
@@ -1,0 +1,23 @@
+package project.main.webstore.domain.answer.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.main.webstore.audit.Auditable;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Answer extends Auditable {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+
+    @Lob
+    private String comment;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/banner/entity/Banner.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/banner/entity/Banner.java
@@ -1,0 +1,24 @@
+package project.main.webstore.domain.banner.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Banner {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+
+    private String imagePath;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/coupon/entity/Coupon.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/coupon/entity/Coupon.java
@@ -1,0 +1,46 @@
+package project.main.webstore.domain.coupon.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.coupon.enums.CouponStatus;
+import project.main.webstore.valueObject.Duration;
+import project.main.webstore.valueObject.Price;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Coupon extends Auditable {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+    private String name;
+    //사용 전 사용 후 만료
+    private CouponStatus couponStatus;
+
+    @Embedded
+    @AttributeOverrides(
+            @AttributeOverride(name="value",column = @Column(name = "DISCOUNT_PRICE"))
+    )
+    private Price discountPrice;
+    @Embedded
+    @AttributeOverrides(
+            @AttributeOverride(name="value",column = @Column(name = "MINIMUM_ORDER_AMOUNT"))
+    )
+    private Price minimumPrice;
+    @Embedded
+    @AttributeOverrides(
+            @AttributeOverride(name="value",column = @Column(name = "MAXIMUM_ADJUST_DISCOUNT"))
+    )
+    private Price maxAdjustedPrice;
+
+    @Embedded
+    private Duration duration;
+
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/coupon/enums/CouponStatus.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/coupon/enums/CouponStatus.java
@@ -1,0 +1,6 @@
+package project.main.webstore.domain.coupon.enums;
+
+public enum CouponStatus {
+    BEFORE_USE,AFTER_USER,EXPIRED
+    ;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/PickedItem.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/PickedItem.java
@@ -1,0 +1,24 @@
+package project.main.webstore.domain.item.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class PickedItem {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+
+    //연관관계매핑
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/like/entity/Like.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/like/entity/Like.java
@@ -1,0 +1,26 @@
+package project.main.webstore.domain.like.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.main.webstore.audit.Auditable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Like extends Auditable {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+    private int count;
+
+    //연관관계 매핑
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/notice/entity/Notice.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/notice/entity/Notice.java
@@ -1,0 +1,25 @@
+package project.main.webstore.domain.notice.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.main.webstore.audit.Auditable;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Notice extends Auditable {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+
+    private String title;
+
+    @Lob
+    private String content;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/question/entity/Question.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/question/entity/Question.java
@@ -1,0 +1,29 @@
+package project.main.webstore.domain.question.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.question.enums.QnaStatus;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Question extends Auditable {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+    private String imagePath;
+    private boolean isSecret;
+
+    @Lob
+    private String comment;
+
+    @Enumerated
+    private QnaStatus qnaStatus = QnaStatus.REGISTER;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/question/enums/QnaStatus.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/question/enums/QnaStatus.java
@@ -1,0 +1,11 @@
+package project.main.webstore.domain.question.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum QnaStatus {
+    REGISTER,ANSWER_COMPLETE
+    ;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/tag/entity/Tag.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/tag/entity/Tag.java
@@ -1,0 +1,26 @@
+package project.main.webstore.domain.tag.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+    private String name;
+
+    //연관관계 매핑
+}
+//협의 후 진행

--- a/BE/backend/src/main/java/project/main/webstore/valueObject/Price.java
+++ b/BE/backend/src/main/java/project/main/webstore/valueObject/Price.java
@@ -1,0 +1,12 @@
+package project.main.webstore.valueObject;
+
+import lombok.Getter;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+@Getter
+public class Price {
+    private int value;
+
+}


### PR DESCRIPTION
# 작업 내용
* 게시판 관련 엔티티 및 item 관련 엔티티 구현완료
* 쿠폰 관련 엔티티 구현

# 작업 회고
쿠폰 엔티티를 구현할 때 고민 했던 것이 price 를 표현하는 자료형을 int로 사용하는 것 이었다.
어차피 숫자로 이루어진 데이터기 때문에 int로 사용해도 무방하나 뭔가 price라는 느낌을 변수명을 보기 전까지는 받기 어려웠다. 
또한 쿠폰에서만 3개 이상 item에서도 사용될 것이면 order관련된 부분에서도 사용 될 것인데 VO로 만드는 것이 조금 더 직관적으로 알 수 있지 않을 까 하는 생각이 들었다. 
     -> VO 로 price 라는 클래스를 만들어서 해당 값을 넣어줬다. 

### price 클래스 만들었을 때의 장점
1. 일단 직관적으로 이것이 가격과 관련된 것이라는 것을 데이터타입에서부터 온몸으로 표헌한다.
2. price 관련된 메서드들을 모두 한 곳에 넣어서 사용할 수있다. -> 조금 더 객체 스러운 코드가 된 것 같다.

<img width="787" alt="image" src="https://github.com/devstoreproject/devstore/assets/116015708/e0404df4-6cea-441f-8f22-a8d7a351f484">

같은 VO의 테이블 명을 다르게 하기 위해 어노테이션을 이용해서 구분 했다.
이렇게 보니 값타입을 쓰는게 좋은 선택이었는지 다시 한번 고민을 하게 되었지만 그래도 price에 관련된 메서드들을 Price 클래스에 추가한다면 분명 도움이 될 것이라고 생각한다.
