### PR TITLE
연관관계 매핑 완료

### DIFF
--- a/BE/backend/src/main/java/project/main/webstore/domain/answer/entity/Answer.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/answer/entity/Answer.java
@@ -3,9 +3,14 @@ package project.main.webstore.domain.answer.entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.question.entity.Question;
+import project.main.webstore.domain.question.enums.QnaStatus;
+import project.main.webstore.domain.users.entity.User;
 
 import javax.persistence.*;
 
+import static javax.persistence.EnumType.STRING;
+import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -17,7 +22,21 @@ public class Answer extends Auditable {
     @GeneratedValue(strategy = IDENTITY)
     @Column(updatable = false)
     private Long id;
+    private boolean isSecret;
+
+    @Enumerated(STRING)
+    private QnaStatus qnaStatus;
 
     @Lob
     private String comment;
+
+    //연관관계 매핑 //
+    @OneToOne(fetch = LAZY)
+    private Question question;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
+
+    // 연관관계 편의 메서드 //
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/Cart.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/Cart.java
@@ -3,6 +3,7 @@ package project.main.webstore.domain.cart.entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import project.main.webstore.valueObject.Price;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -18,6 +19,15 @@ public class Cart {
     @Column(updatable = false)
     private Long id;
     private int count;
-    private long deliveryPrice;
-    private long totalPrice;
+
+    @Embedded
+    @AttributeOverrides(
+            @AttributeOverride(name="value",column = @Column(name = "DELIVERY_PRICE"))
+    )
+    private Price deliveryPrice;
+
+    //양방향 연관계
+    @OneToMany(mappedBy = "cart")
+    private List<CartItem> cartItemList = new ArrayList<>();
+
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/Cart.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/Cart.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Getter
@@ -14,7 +16,7 @@ public class Cart {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(updatable = false)
-    private long id;
+    private Long id;
     private int count;
     private long deliveryPrice;
     private long totalPrice;

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/CartItem.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/CartItem.java
@@ -2,8 +2,13 @@ package project.main.webstore.domain.cart.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import project.main.webstore.domain.item.entity.Item;
 
 import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @NoArgsConstructor

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/CartItem.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/CartItem.java
@@ -11,11 +11,22 @@ import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 @Entity
 public class CartItem {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = IDENTITY)
     @Column(updatable = false)
-    private long id;
+    private Long id;
+
+    // 연관관계 매핑 //
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "ITEM_ID")
+    private Item item;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "CART_ID")
+    private Cart cart;
+
+
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/coupon/entity/Coupon.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/coupon/entity/Coupon.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.main.webstore.audit.Auditable;
 import project.main.webstore.domain.coupon.enums.CouponStatus;
+import project.main.webstore.domain.payment.entity.Payment;
 import project.main.webstore.valueObject.Duration;
 import project.main.webstore.valueObject.Price;
 
@@ -12,8 +13,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
+import static project.main.webstore.domain.coupon.enums.CouponStatus.BEFORE_USE;
 
 @Entity
 @Getter
@@ -25,7 +28,7 @@ public class Coupon extends Auditable {
     private Long id;
     private String name;
     //사용 전 사용 후 만료
-    private CouponStatus couponStatus;
+    private CouponStatus couponStatus = BEFORE_USE;
     private String serialNumber = UUID.randomUUID().toString();
     @Embedded
     @AttributeOverrides(
@@ -46,4 +49,12 @@ public class Coupon extends Auditable {
     @Embedded
     private Duration duration;
 
+    // 연관관계 매핑 //
+    //user 여러개의 쿠폰이 여러개의 유저에 갈수 있자ㅛ   여러개의 쿠폰이 하나의 유저에 제공된다. 여러 유저는 하나의 쿠폰을 가진다.
+    @OneToMany(mappedBy = "coupon")
+    private List<CouponUser> couponUsers = new ArrayList<>();
+
+    //payment  쿠폰 결제 : 하나의 결제에 여러개의 쿠폰을 사용할 수 있다. ->   여러개의 쿠폰이 하나의 결제에 사용이 가능하다. ManyToOne
+    @ManyToOne(fetch = LAZY)
+    private Payment payment;
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/coupon/entity/Coupon.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/coupon/entity/Coupon.java
@@ -8,6 +8,8 @@ import project.main.webstore.valueObject.Duration;
 import project.main.webstore.valueObject.Price;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import static javax.persistence.GenerationType.IDENTITY;

--- a/BE/backend/src/main/java/project/main/webstore/domain/coupon/entity/CouponUser.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/coupon/entity/CouponUser.java
@@ -1,23 +1,27 @@
-package project.main.webstore.domain.like.entity;
+package project.main.webstore.domain.coupon.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.users.entity.User;
 
 import javax.persistence.*;
 
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
-@Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Like extends Auditable {
+@Entity
+public class CouponUser {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(updatable = false)
     private Long id;
-    private int count;
+    
+    // 연관관계 매핑 //
+    @ManyToOne
+    private Coupon coupon;
+    @ManyToOne
+    private User user;
 
-    //연관관계 매핑
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
@@ -2,6 +2,7 @@ package project.main.webstore.domain.item.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import project.main.webstore.domain.cart.entity.CartItem;
 import project.main.webstore.domain.item.enums.Category;
 import project.main.webstore.domain.item.enums.ItemStatus;
 import project.main.webstore.valueObject.Price;
@@ -42,4 +43,11 @@ public class Item {
 
     @OneToMany(mappedBy = "item")
     private List<Spec> specList = new ArrayList<>();
+    @OneToMany(mappedBy = "cart")
+    private List<CartItem> cartItems = new ArrayList<>();
+
+    //PicedItem 연관관계 매핑
+    @OneToOne(fetch = LAZY)
+    private PickedItem pickedItem;
+
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
@@ -11,7 +11,9 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import static javax.persistence.EnumType.STRING;
 import static javax.persistence.FetchType.EAGER;
+import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -34,13 +36,14 @@ public class Item {
     private String description;
     //상세 정보
 
-    @Enumerated
+    @Enumerated(STRING)
     private ItemStatus itemStatus = ItemStatus.ON_STACK;
     @Embedded
     private Price price;
-    @Enumerated
+    @Enumerated(STRING)
     private Category category;
 
+    // 연관관계 매핑 //
     @OneToMany(mappedBy = "item")
     private List<Spec> specList = new ArrayList<>();
     @OneToMany(mappedBy = "cart")

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/PickedItem.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/PickedItem.java
@@ -2,12 +2,11 @@ package project.main.webstore.domain.item.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import project.main.webstore.domain.users.entity.User;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 
+import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -21,4 +20,7 @@ public class PickedItem {
     private Long id;
 
     //연관관계매핑
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name ="USER_ID")
+    private User user;
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/like/entity/Like.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/like/entity/Like.java
@@ -23,4 +23,13 @@ public class Like extends Auditable {
     private int count;
 
     //연관관계 매핑
+    // item
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "ITEM_ID")
+    private Item item;
+    //user
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
+
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/like/entity/Like.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/like/entity/Like.java
@@ -3,9 +3,12 @@ package project.main.webstore.domain.like.entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.item.entity.Item;
+import project.main.webstore.domain.users.entity.User;
 
 import javax.persistence.*;
 
+import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 

--- a/BE/backend/src/main/java/project/main/webstore/domain/notice/entity/Notice.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/notice/entity/Notice.java
@@ -3,12 +3,14 @@ package project.main.webstore.domain.notice.entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.users.entity.User;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
 import static javax.persistence.FetchType.EAGER;
+import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -23,9 +25,12 @@ public class Notice extends Auditable {
 
     private String title;
 
-    @ElementCollection(fetch = EAGER)
-    List<String> imagePathList = new ArrayList<>();
-
     @Lob
     private String content;
+
+    @ElementCollection(fetch = EAGER)
+    List<String> imagePathList = new ArrayList<>();
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/entity/OrderHistory.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/entity/OrderHistory.java
@@ -24,13 +24,34 @@ public class OrderHistory extends Auditable {
     @Column(updatable = false)
     private long id;
     private String orderNumber;
-    private long deliveryPrice;
-    private long totalPrice;
-    private long discountedPrice;
+
+    @Embedded
+    @AttributeOverrides(
+            @AttributeOverride(name = "value", column = @Column(name = "DELIVERY_PRICE"))
+    )
+    private Price deliveryPrice;
+    @Embedded
+    @AttributeOverrides(
+            @AttributeOverride(name = "value", column = @Column(name = "TOTAL_PRICE"))
+    )
+    private Price totalPrice;
+    @Embedded
+    @AttributeOverrides(
+            @AttributeOverride(name = "value", column = @Column(name = "DISCOUNT_PRICE"))
+    )
+    private Price discountedPrice;
 
     @Embedded
     private Address address;
 
     @Enumerated(STRING)
     private OrderStatus orderStatus = OrderStatus.INCART;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
+    @OneToOne(fetch = LAZY)
+    private Cart cart;
+    @OneToOne(fetch = LAZY)
+    private Payment payment;
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/entity/OrderHistory.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/entity/OrderHistory.java
@@ -4,8 +4,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.cart.entity.Cart;
 import project.main.webstore.domain.orderHistory.enums.OrderStatus;
+import project.main.webstore.domain.payment.entity.Payment;
+import project.main.webstore.domain.users.entity.User;
 import project.main.webstore.valueObject.Address;
+import project.main.webstore.valueObject.Price;
 
 import javax.persistence.*;
 

--- a/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/entity/OrderHistory.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/entity/OrderHistory.java
@@ -14,6 +14,7 @@ import project.main.webstore.valueObject.Price;
 import javax.persistence.*;
 
 import static javax.persistence.EnumType.STRING;
+import static javax.persistence.FetchType.LAZY;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,7 +23,7 @@ public class OrderHistory extends Auditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(updatable = false)
-    private long id;
+    private Long id;
     private String orderNumber;
 
     @Embedded

--- a/BE/backend/src/main/java/project/main/webstore/domain/payment/entity/Payment.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/payment/entity/Payment.java
@@ -17,7 +17,7 @@ import static javax.persistence.GenerationType.IDENTITY;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Payment /*extends Auditable*/ {
+public class Payment extends Auditable {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(updatable = false)

--- a/BE/backend/src/main/java/project/main/webstore/domain/payment/entity/Payment.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/payment/entity/Payment.java
@@ -1,38 +1,39 @@
 package project.main.webstore.domain.payment.entity;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.domain.Auditable;
+import project.main.webstore.audit.Auditable;
 import project.main.webstore.domain.coupon.entity.Coupon;
+import project.main.webstore.domain.orderHistory.entity.OrderHistory;
 import project.main.webstore.domain.payment.enums.PaymentStatus;
+import project.main.webstore.domain.users.entity.User;
 
 import javax.persistence.*;
 
-import java.time.LocalDateTime;
-
+import static javax.persistence.EnumType.STRING;
+import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = PROTECTED)
 @Entity
 public class Payment extends Auditable {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(updatable = false)
-    private long Id;
-//    @ManyToOne
-//    @JoinColumn(name = "user_id")
-//    private Users user;
-//    @ManyToOne
-//    @JoinColumn(name = "coupon_id")
-//    private Coupon coupon;
-//    @ManyToOne
-//    @JoinColumn(name = "orderHistory_id")
-//    private OrderHistory orderHistory;
+    private Long id;
 
-    @Enumerated(EnumType.STRING)
+    @Enumerated(STRING)
     private PaymentStatus paymentStatus;
 
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "COUPON_ID")
+    private Coupon coupon;
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "ORDERHISTORY_ID")
+    private OrderHistory orderHistory;
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/question/entity/Question.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/question/entity/Question.java
@@ -4,12 +4,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.main.webstore.audit.Auditable;
 import project.main.webstore.domain.question.enums.QnaStatus;
+import project.main.webstore.domain.users.entity.User;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import static javax.persistence.EnumType.STRING;
 import static javax.persistence.FetchType.EAGER;
+import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -28,6 +31,9 @@ public class Question extends Auditable {
     @Lob
     private String comment;
 
-    @Enumerated
+    @Enumerated(STRING)
     private QnaStatus qnaStatus = QnaStatus.REGISTER;
+
+    @ManyToOne(fetch = LAZY)
+    private User user;
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/entity/Review.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/entity/Review.java
@@ -3,6 +3,8 @@ package project.main.webstore.domain.review.entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.item.entity.Item;
+import project.main.webstore.domain.users.entity.User;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -12,14 +14,19 @@ import java.util.List;
 @NoArgsConstructor
 @Entity
 public class Review extends Auditable {
+    @ElementCollection
+    List<String> imagePathList = new ArrayList<>();
     @Id
     @GeneratedValue
     @Column(unique = true, updatable = false)
-    private long id;
+    private Long id;
     private String comment;
     private int rating;
 
-    @ElementCollection
-    List<String> imagePathList = new ArrayList<>();
-
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ITEM_ID")
+    private Item item;
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/users/entity/User.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/users/entity/User.java
@@ -40,7 +40,8 @@ public class User extends Auditable {
     @Enumerated(STRING)
     private UserRole userRole = UserRole.CLIENT;
 
-    public User(String nickName,String profileImage ,String password, String email, int mileage, Address address, Grade grade, ProviderId providerId, UserRole userRole) {
+
+    public User(String nickName, String profileImage, String password, String email, int mileage, Address address, Grade grade, ProviderId providerId, UserRole userRole) {
         this.nickName = nickName;
         this.profileImage = profileImage;
         this.password = password;


### PR DESCRIPTION
# 작업 내용
1. 연관관계 매핑
2. 작업 중 엔티티 필드 이상 여부 체크

# 작업 회고
엔티티 연관관계 매핑 중 단방향 연관관계 매핑 우선 작업
양방향 매핑이 필요하다고 판단되면 해당 작업을 하는 사람이 그 때 연관관계 작업 진행

## 단방향만 걸어둔 이유
양방향 연관관계 매핑 시 순환 참조 문제 발생할 가능성이 존재 하기 때문에 단방향 연관관계 매핑만 했습니다.
