### PR TITLE
Service, Controller 계층 결합도 약화를 위한 파라미터 및 반환값 수정

### DIFF
--- a/BE/backend/src/main/java/project/main/webstore/domain/image/dto/ImageInfoDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/image/dto/ImageInfoDto.java
@@ -1,5 +1,6 @@
 package project.main.webstore.domain.image.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
@@ -8,6 +9,7 @@ import java.util.UUID;
 
 @Getter
 public class ImageInfoDto {
+    private Long id;
     private MultipartFile multipartFile;
     @Setter
     private MultipartFile thumbFile;
@@ -21,7 +23,9 @@ public class ImageInfoDto {
     private String fileName;
     private String ext;
 
-    public ImageInfoDto(MultipartFile multipartFile, int order, boolean representative, String uploadDir) {
+    @Builder(builderMethodName = "dtoBuilder")
+    public ImageInfoDto(MultipartFile multipartFile, Long id, int order, boolean representative, String uploadDir) {
+        this.id = id;
         this.multipartFile = multipartFile;
         this.order = order;
         this.representative = representative;

--- a/BE/backend/src/main/java/project/main/webstore/domain/image/dto/ImageSortDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/image/dto/ImageSortDto.java
@@ -6,6 +6,12 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ImageSortDto {
+    private Long id;
     private int orderNumber;
     private boolean representative;
+
+    public ImageSortDto(int orderNumber, boolean representative) {
+        this.orderNumber = orderNumber;
+        this.representative = representative;
+    }
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/image/mapper/ImageMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/image/mapper/ImageMapper.java
@@ -1,0 +1,33 @@
+package project.main.webstore.domain.image.mapper;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import project.main.webstore.domain.image.dto.ImageInfoDto;
+import project.main.webstore.domain.image.dto.ImageSortDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ImageMapper {
+    public ImageInfoDto toLocalDto(MultipartFile file, ImageSortDto sortDto, String uploadDir){
+        return ImageInfoDto.dtoBuilder()
+                .multipartFile(file)
+                .order(sortDto.getOrderNumber())
+                .representative(sortDto.isRepresentative())
+                .id(sortDto.getId())
+                .uploadDir(uploadDir)
+                .build();
+    }
+    public List<ImageInfoDto> toLocalDtoList(List<MultipartFile>fileList,List<ImageSortDto> imageSortDto,String uploadDir){
+        List<ImageInfoDto> result = new ArrayList<>();
+        //TODO: 예외처리 하나 있으면 좋아보인다. mapping Exception 이런것들
+
+        for(int i = 0 ; i < fileList.size(); i++){
+            ImageInfoDto imageInfoDto = toLocalDto(fileList.get(i), imageSortDto.get(i), uploadDir);
+            result.add(imageInfoDto);
+        }
+        return result;
+    }
+
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/dto/ReviewUpdateRequestDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/dto/ReviewUpdateRequestDto.java
@@ -2,7 +2,7 @@ package project.main.webstore.domain.review.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import project.main.webstore.domain.image.dto.ImageSortPatchInfo;
+import project.main.webstore.domain.image.dto.ImageSortDto;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
@@ -18,5 +18,5 @@ public class ReviewUpdateRequestDto {
     private List<Long> deleteImageId;
     //전체 사진을 다시 받아온다? 이거 리소스에 상당한 낭비를 가져올 것 같다.
     //요청 시 마다 모든 파일을 전달한다면?
-    private List<ImageSortPatchInfo> imageSortAndRepresentativeInfo;
+    private List<ImageSortDto> imageSortAndRepresentativeInfo;
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/entity/Review.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/entity/Review.java
@@ -68,6 +68,19 @@ public class Review extends Auditable {
         this.rating = dto.getRating();
     }
 
+    @Builder(builderMethodName = "patchBuilder")
+    public Review(Long id, String comment, Integer rating) {
+        this.id = id;
+        this.comment = comment;
+        this.rating = rating;
+    }
+
+    @Builder(builderMethodName = "postBuilder")
+    public Review(String comment, Integer rating) {
+        this.comment = comment;
+        this.rating = rating;
+    }
+
     @Builder(builderMethodName = "stubBuilder",buildMethodName = "stubBuild")
     public Review(Long id, String comment, Integer rating, User user, Item item, List<ReviewImage> reviewImageList) {
         this.id = id;

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/mapper/ReviewMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/mapper/ReviewMapper.java
@@ -3,24 +3,46 @@ package project.main.webstore.domain.review.mapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
+import project.main.webstore.domain.image.dto.ImageSortDto;
 import project.main.webstore.domain.review.dto.ReviewGetResponseDto;
+import project.main.webstore.domain.review.dto.ReviewIdResponseDto;
+import project.main.webstore.domain.review.dto.ReviewPostRequestDto;
+import project.main.webstore.domain.review.dto.ReviewUpdateRequestDto;
 import project.main.webstore.domain.review.entity.Review;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Component
 public class ReviewMapper {
+
+    private Long userId;
+    private String comment;
+    private int rating;
+    private List<ImageSortDto> infoList;
+
+    public Review toEntity(ReviewPostRequestDto post){
+        return Review.postBuilder()
+                .rating(post.getRating())
+                .comment(post.getComment())
+                .build();
+    }
+
+    public Review toEntity(ReviewUpdateRequestDto patch,Long reviewId){
+        return Review.patchBuilder()
+                .id(reviewId)
+                .comment(patch.getComment())
+                .rating(patch.getRating())
+                .build();
+    }
+
+    public ReviewIdResponseDto toDto(Review review){
+        return new ReviewIdResponseDto(review.getId(),review.getUser().getId(),review.getItem().getId());
+    }
+
     public ReviewGetResponseDto reviewGetResponse(Review review){
         return ReviewGetResponseDto.dtoBuilder()
                 .review(review)
                 .dtoBuild();
-    }
-
-    public List<ReviewGetResponseDto> reviewGetListResponse(List<Review> reviewList) {
-        return reviewList.stream()
-                .map(this::reviewGetResponse)
-                .collect(Collectors.toList());
     }
 
     public Page<ReviewGetResponseDto> reviewGetPageResponse(Page<Review> reviewPage){

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewService.java
@@ -3,22 +3,15 @@ package project.main.webstore.domain.review.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 import project.main.webstore.domain.image.dto.ImageInfoDto;
-import project.main.webstore.domain.image.dto.ImageSortDto;
-import project.main.webstore.domain.image.dto.ImageSortPatchInfo;
 import project.main.webstore.domain.image.entity.Image;
 import project.main.webstore.domain.image.entity.ReviewImage;
-import project.main.webstore.domain.review.dto.ReviewIdResponseDto;
-import project.main.webstore.domain.review.dto.ReviewPostRequestDto;
-import project.main.webstore.domain.review.dto.ReviewUpdateRequestDto;
 import project.main.webstore.domain.review.entity.Review;
 import project.main.webstore.domain.review.repository.ReviewRepository;
 import project.main.webstore.exception.BusinessLogicException;
 import project.main.webstore.exception.CommonExceptionCode;
 import project.main.webstore.utils.FileUploader;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -32,43 +25,43 @@ public class ReviewService {
     private final ReviewValidService reviewValidService;
     private final FileUploader fileUploader;
 
-    public ReviewIdResponseDto postReview(ReviewPostRequestDto dto, Long userId, Long itemId, List<MultipartFile> fileList) {
+
+    public Review postReview(Review review, Long userId, Long itemId) {
         //TODO : User 검증 및 item 검증 필요
-        Review review = new Review(dto);
-        List<ImageSortDto> imageSortInfoList = dto.getInfoList();
+        //TODO: User, Iteme Review와 매핑이 필요하다.
+        Review savedReview = reviewRepository.save(review);
 
-        if (imageSortInfoList.size() != fileList.size()) {
-            throw new BusinessLogicException(CommonExceptionCode.IMAGE_INFO_COUNT_MISMATCH);
-        }
 
-        List<ImageInfoDto> infoList = createImageInfoList(fileList, imageSortInfoList);
+        return savedReview;
+    }
+
+    public Review postReview(List<ImageInfoDto> imageInfoList, Review review, Long userId, Long itemId) {
+        //TODO : User 검증 및 item 검증 필요
+
+//      TODO : 서비스단에서 체크
+//        if (imageSortInfoList.size() != fileList.size()) {
+//            throw new BusinessLogicException(CommonExceptionCode.IMAGE_INFO_COUNT_MISMATCH);
+//        }
 
         //이미지 저장 로직
-        List<Image> imageList = fileUploader.uploadImage(infoList);
+        List<Image> imageList = fileUploader.uploadImage(imageInfoList);
         //이미지 DB 저장 로직
         imageList.stream().map(image -> new ReviewImage(image, review)).forEach(review::addReviewImage);
         Review savedReview = reviewRepository.save(review);
-        return new ReviewIdResponseDto(savedReview.getId(), savedReview.getUser().getId(), savedReview.getItem().getId());
+        return savedReview;
     }
 
-    public ReviewIdResponseDto postReview(ReviewPostRequestDto dto, Long userId, Long itemId) {
-        //TODO : User 검증 및 item 검증 필요
-        //TODO: User, Iteme Review와 매핑이 필요하다.
-        Review review = new Review(dto);
-        Review savedReview = reviewRepository.save(review);
-
-        return new ReviewIdResponseDto(savedReview.getId(), savedReview.getUser().getId(),savedReview.getItem().getId());
-    }
-
-    public ReviewIdResponseDto updateReview(ReviewUpdateRequestDto dto, List<MultipartFile> fileList, Long userId, Long itemId, Long reviewId) {
+    public Review patchReview(List<ImageInfoDto> imageInfoDtoList,List<Long> deleteIdList,Review review, Long userId, Long itemId, Long reviewId) {
         //TODO: 연관관계 찾기
-        Review review = reviewValidService.validReview(reviewId);
+        Review findReview = reviewValidService.validReview(reviewId);
         //기본적인 정보 존재한다면 변경
-        Optional.ofNullable(dto.getRating()).ifPresent((review::setRating));
-        Optional.ofNullable(dto.getComment()).ifPresent((review::setComment));
-        patchImage(dto.getDeleteImageId(), fileList, dto.getImageSortAndRepresentativeInfo(), review);
+        Optional.ofNullable(review.getRating()).ifPresent((findReview::setRating));
+        Optional.ofNullable(review.getComment()).ifPresent((findReview::setComment));
 
-        return new ReviewIdResponseDto(reviewId, userId, itemId);
+
+        patchImage(imageInfoDtoList, findReview,deleteIdList);
+
+        return findReview;
     }
 
     public void deleteReview(Long reviewId) {
@@ -81,74 +74,38 @@ public class ReviewService {
 
     // #### 내부 동작 메서드 #### //
     //사진 저장
-    private void patchImage(List<Long> deleteImageId, List<MultipartFile> fileList, List<ImageSortPatchInfo> sortDtoList, Review review) {
+    private void patchImage(List<ImageInfoDto> infoList, Review review,List<Long> deleteIdList) {
         List<ReviewImage> imageList = review.getReviewImageList();
 
-        changeRepresentative(sortDtoList, review, imageList);
+        List<ImageInfoDto> addImageList = infoList.stream().filter(info -> info.getId() == null).collect(Collectors.toList());
+        List<ImageInfoDto> savedImageList = infoList.stream().filter(info -> info.getId() != null).collect(Collectors.toList());
 
-        if (!deleteImageId.isEmpty()) {
+        changeRepresentativeAndOrder(savedImageList, imageList);
+
+
+        if (deleteIdList.isEmpty() == false) {
             //사진 삭제하는 경우
-            List<ReviewImage> deleteImage = findImageById(deleteImageId, review);
+            List<ReviewImage> deleteImage = findImageById(deleteIdList, review);
             List<String> deleteImagePath = deleteImage.stream().map(Image::getImagePath).collect(Collectors.toList());
 
-            deleteImageList(imageList, deleteImageId, deleteImagePath);
-            //사진 삭제 후 등록 진행
-            if (!fileList.isEmpty()) {
-                saveAndAddImage(fileList, sortDtoList, review);
-            }
+            deleteImageList(imageList, deleteIdList, deleteImagePath);
         }
-        //사진 등록만 진행
-        else {
-            if (!fileList.isEmpty()) {
-                saveAndAddImage(fileList, sortDtoList, review);
-            }
-        }
+        List<Image> uploadedImageList = fileUploader.uploadImage(addImageList);
+        uploadedImageList.stream().map(image -> new ReviewImage(image, review)).forEach(review::addReviewImage);
+
     }
 
-    private void changeRepresentative(List<ImageSortPatchInfo> sortDtoList, Review review, List<ReviewImage> imageList) {
-        //기존에 있는 대표 이미지 false 변경
-        review.getReviewImageList().stream()
-                .filter(Image::isRepresentative)
-                .forEach(image->image.setRepresentative(false));
+    private void changeRepresentativeAndOrder(List<ImageInfoDto> requestInfoList, List<ReviewImage> imageList) {
+        for(int i = 0; i < requestInfoList.size(); i++){
+            ImageInfoDto requestInfo = requestInfoList.get(i);
 
-        //요청에서 받은 대표 이미지 번호 확인
-        Optional<ImageSortPatchInfo> representative = sortDtoList.stream()
-                .filter(ImageSortPatchInfo::isRepresentative)
-                .findFirst();
-        ImageSortPatchInfo info = representative.orElseThrow(() -> new BusinessLogicException(CommonExceptionCode.IMAGE_HAS_ALWAYS_REPRESENTATIVE));
+            Optional<ReviewImage> first = imageList.stream().filter(image -> image.getId() == requestInfo.getId()).findFirst();
 
-        //대표 값이 기존에 저장된 파일 내에 있을 경우 변경
-        if (info.getImageId() != null) {
-            imageList.stream()
-                    .filter(image -> image.getId() == info.getImageId())
-                    .forEach(reviewImage -> reviewImage.setRepresentative(info.isRepresentative()));
+            ReviewImage image = first.orElseThrow(() -> new BusinessLogicException(CommonExceptionCode.IMAGE_NOT_FOUND));
+
+            image.setRepresentative(requestInfo.isRepresentative());
+            image.setImageOrder(requestInfo.getOrder());
         }
-    }
-
-    private List<ImageInfoDto> createImageInfoList(List<MultipartFile> fileList, List<?> list) {
-        List<ImageInfoDto> infoList = new ArrayList<>();
-
-        for (int i = 0; i < fileList.size(); i++) {
-            Object item = list.get(i);
-            int orderNumber;
-            boolean representative;
-
-            if (item instanceof ImageSortDto) {
-                ImageSortDto imageSortDto = (ImageSortDto) item;
-                orderNumber = imageSortDto.getOrderNumber();
-                representative = imageSortDto.isRepresentative();
-            } else if (item instanceof ImageSortPatchInfo) {
-                ImageSortPatchInfo imageSortPatchInfo = (ImageSortPatchInfo) item;
-                orderNumber = imageSortPatchInfo.getOrderNumber();
-                representative = imageSortPatchInfo.isRepresentative();
-            } else {
-                throw new IllegalArgumentException("잘못된 요청입니다.");
-            }
-
-            ImageInfoDto infoDto = new ImageInfoDto(fileList.get(i), orderNumber, representative, UPLOAD_DIR);
-            infoList.add(infoDto);
-        }
-        return infoList;
     }
 
     private void deleteImageList(List<ReviewImage> reviewImageList, List<Long> deleteId, List<String> deleteImagePath) {
@@ -163,18 +120,6 @@ public class ReviewService {
             reviewImageList.remove(index);
             deleteImage(deleteImagePath);
         }
-    }
-
-    private void saveAndAddImage(List<MultipartFile> fileList, List<ImageSortPatchInfo> sortDtoList, Review review) {
-        List<ImageSortPatchInfo> uploadImageSortInfo = sortDtoList.stream().filter(info -> info.getImageId() == null).collect(Collectors.toList());
-
-        //검증
-        if (uploadImageSortInfo.size() != fileList.size())
-            throw new BusinessLogicException(CommonExceptionCode.IMAGE_ERROR);
-
-        List<ImageInfoDto> infoList = createImageInfoList(fileList, uploadImageSortInfo);
-        List<Image> images = fileUploader.uploadImage(infoList);
-        images.stream().map(image -> new ReviewImage(image, review)).forEach(review::addReviewImage);
     }
 
     private List<ReviewImage> findImageById(List<Long> deleteImageId, Review review) {

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewService.java
@@ -35,6 +35,17 @@ public class ReviewService {
         return savedReview;
     }
 
+    private static void imageValid(List<ImageInfoDto> imageInfoList) {
+        boolean check = imageInfoList.stream().noneMatch(ImageInfoDto::isRepresentative);
+        if(check){
+            throw new BusinessLogicException(CommonExceptionCode.IMAGE_HAS_ALWAYS_REPRESENTATIVE);
+        }
+        check = imageInfoList.stream().distinct().count() != imageInfoList.size();
+        if(check){
+            throw new BusinessLogicException(CommonExceptionCode.IMAGE_ORDER_ALWAYS_UNIQUE);
+        }
+    }
+
     public Review postReview(List<ImageInfoDto> imageInfoList, Review review, Long userId, Long itemId) {
         //TODO : User 검증 및 item 검증 필요
 
@@ -42,6 +53,9 @@ public class ReviewService {
 //        if (imageSortInfoList.size() != fileList.size()) {
 //            throw new BusinessLogicException(CommonExceptionCode.IMAGE_INFO_COUNT_MISMATCH);
 //        }
+
+        //TODO:메서드 따로 뺴야함
+        imageValid(imageInfoList);
 
         //이미지 저장 로직
         List<Image> imageList = fileUploader.uploadImage(imageInfoList);
@@ -51,7 +65,7 @@ public class ReviewService {
         return savedReview;
     }
 
-    public Review patchReview(List<ImageInfoDto> imageInfoDtoList,List<Long> deleteIdList,Review review, Long userId, Long itemId, Long reviewId) {
+    public Review patchReview(List<ImageInfoDto> imageInfoList,List<Long> deleteIdList,Review review, Long userId, Long itemId, Long reviewId) {
         //TODO: 연관관계 찾기
         Review findReview = reviewValidService.validReview(reviewId);
         //기본적인 정보 존재한다면 변경
@@ -59,7 +73,11 @@ public class ReviewService {
         Optional.ofNullable(review.getComment()).ifPresent((findReview::setComment));
 
 
-        patchImage(imageInfoDtoList, findReview,deleteIdList);
+        //TODO:메서드 따로 뺴야함
+        imageValid(imageInfoList);
+
+
+        patchImage(imageInfoList, findReview,deleteIdList);
 
         return findReview;
     }

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewService.java
@@ -95,21 +95,23 @@ public class ReviewService {
     private void patchImage(List<ImageInfoDto> infoList, Review review,List<Long> deleteIdList) {
         List<ReviewImage> imageList = review.getReviewImageList();
 
-        List<ImageInfoDto> addImageList = infoList.stream().filter(info -> info.getId() == null).collect(Collectors.toList());
-        List<ImageInfoDto> savedImageList = infoList.stream().filter(info -> info.getId() != null).collect(Collectors.toList());
+        if(infoList.isEmpty() == false){
+            List<ImageInfoDto> addImageList = infoList.stream().filter(info -> info.getId() == null).collect(Collectors.toList());
+            List<ImageInfoDto> savedImageList = infoList.stream().filter(info -> info.getId() != null).collect(Collectors.toList());
 
-        changeRepresentativeAndOrder(savedImageList, imageList);
+            changeRepresentativeAndOrder(savedImageList, imageList);
 
 
-        if (deleteIdList.isEmpty() == false) {
-            //사진 삭제하는 경우
-            List<ReviewImage> deleteImage = findImageById(deleteIdList, review);
-            List<String> deleteImagePath = deleteImage.stream().map(Image::getImagePath).collect(Collectors.toList());
+            if (deleteIdList != null) {
+                //사진 삭제하는 경우
+                List<ReviewImage> deleteImage = findImageById(deleteIdList, review);
+                List<String> deleteImagePath = deleteImage.stream().map(Image::getImagePath).collect(Collectors.toList());
 
-            deleteImageList(imageList, deleteIdList, deleteImagePath);
+                deleteImageList(imageList, deleteIdList, deleteImagePath);
+            }
+            List<Image> uploadedImageList = fileUploader.uploadImage(addImageList);
+            uploadedImageList.stream().map(image -> new ReviewImage(image, review)).forEach(review::addReviewImage);
         }
-        List<Image> uploadedImageList = fileUploader.uploadImage(addImageList);
-        uploadedImageList.stream().map(image -> new ReviewImage(image, review)).forEach(review::addReviewImage);
 
     }
 

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewService.java
@@ -40,7 +40,7 @@ public class ReviewService {
         if(check){
             throw new BusinessLogicException(CommonExceptionCode.IMAGE_HAS_ALWAYS_REPRESENTATIVE);
         }
-        check = imageInfoList.stream().distinct().count() != imageInfoList.size();
+        check = imageInfoList.stream().map(ImageInfoDto::getOrder).distinct().count() != imageInfoList.size();
         if(check){
             throw new BusinessLogicException(CommonExceptionCode.IMAGE_ORDER_ALWAYS_UNIQUE);
         }

--- a/BE/backend/src/main/java/project/main/webstore/exception/CommonExceptionCode.java
+++ b/BE/backend/src/main/java/project/main/webstore/exception/CommonExceptionCode.java
@@ -14,7 +14,8 @@ public enum CommonExceptionCode implements ExceptionCode {
     IMAGE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"이미지 파일의 해쉬값을 찾을 수 없습니다."),
     IMAGE_ALREADY_HAS(HttpStatus.BAD_REQUEST,"이미지가 이미 존재합니다."),
     IMAGE_INFO_COUNT_MISMATCH(HttpStatus.BAD_REQUEST,"이미지와 정보의 수가 일치하지 않습니다."),
-    IMAGE_HAS_ALWAYS_REPRESENTATIVE(HttpStatus.BAD_REQUEST,"대표 이미지가 한개 있어야합니다.")
+    IMAGE_HAS_ALWAYS_REPRESENTATIVE(HttpStatus.BAD_REQUEST,"대표 이미지가 한개 있어야합니다."),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"이미지를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/BE/backend/src/main/java/project/main/webstore/exception/CommonExceptionCode.java
+++ b/BE/backend/src/main/java/project/main/webstore/exception/CommonExceptionCode.java
@@ -16,6 +16,7 @@ public enum CommonExceptionCode implements ExceptionCode {
     IMAGE_INFO_COUNT_MISMATCH(HttpStatus.BAD_REQUEST,"이미지와 정보의 수가 일치하지 않습니다."),
     IMAGE_HAS_ALWAYS_REPRESENTATIVE(HttpStatus.BAD_REQUEST,"대표 이미지가 한개 있어야합니다."),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND,"이미지를 찾을 수 없습니다."),
+    IMAGE_ORDER_ALWAYS_UNIQUE(HttpStatus.BAD_REQUEST,"이미지 순서는 중복될 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/BE/backend/src/test/java/project/main/webstore/domain/review/service/ReviewServiceTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/review/service/ReviewServiceTest.java
@@ -9,12 +9,8 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
+import project.main.webstore.domain.image.dto.ImageInfoDto;
 import project.main.webstore.domain.image.entity.ReviewImage;
-import project.main.webstore.domain.review.dto.ReviewIdResponseDto;
-import project.main.webstore.domain.review.dto.ReviewPostRequestDto;
-import project.main.webstore.domain.review.dto.ReviewUpdateRequestDto;
 import project.main.webstore.domain.review.entity.Review;
 import project.main.webstore.domain.review.repository.ReviewRepository;
 import project.main.webstore.domain.review.stub.ReviewStub;
@@ -22,15 +18,11 @@ import project.main.webstore.exception.BusinessLogicException;
 import project.main.webstore.stub.ImageStub;
 import project.main.webstore.utils.FileUploader;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 
 @ExtendWith(MockitoExtension.class)
 class ReviewServiceTest {
@@ -52,107 +44,72 @@ class ReviewServiceTest {
     @DisplayName("리뷰 작성 : 성공, 이미지 파일 없음")
     void postReviewTest() {
         //given
-        ReviewPostRequestDto reviewPostRequestDto = reviewStub.reviewPostRequestDtoNoImage(userId);
+
         Review findReview = reviewStub.createReview(userId, itemId, reviewId);
         //TODO : user, item 서비스 코드 생성 시 해당 검증 추가 필요
         given(reviewRepository.save(ArgumentMatchers.any(Review.class))).willReturn(findReview);
 
         //when
-        ReviewIdResponseDto expected = reviewService.postReview(reviewPostRequestDto, userId, itemId);
+        Review result = reviewService.postReview(findReview, userId, itemId);
         //then
 
         SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(expected.getReviewId()).as("리뷰 Id는 생성되는 리뷰 Id와 일치해야합니다.").isEqualTo(reviewId);
-            softAssertions.assertThat(expected.getUserId()).as("사용자 Id는 요청 시 받는 사용자 Id 와 일치 해야합니다.").isEqualTo(userId);
-            softAssertions.assertThat(expected.getItemId()).as("아이템 Id는 요청 시 받는 아이템 Id 와 일치 해야합니다.").isEqualTo(itemId);
+                softAssertions.assertThat(result.getUser().getId()).as("review의 User엔티티의 id틑 post 받은 것과 동일해야합니다.").isEqualTo(userId);
+                softAssertions.assertThat(result.getItem().getId()).as("review의 Item엔티티의 id틑 post 받은 것과 동일해야합니다.").isEqualTo(userId);
         });
 
     }
     @Test
     @DisplayName("리뷰 작성 : 성공, 사진 파일 2개장 존재, ")
     void postReviewAndImageTest() throws IOException {
-        String fileName = "testImage";
-        String ext = "png";
-        String path = "src/test/resources/image/testImage.png";
-        FileInputStream fileInputStream1 = new FileInputStream(new File(path));
-        FileInputStream fileInputStream2 = new FileInputStream(new File(path));
-        List<MultipartFile> fileList = new ArrayList<>();
+        List<ImageInfoDto> imageInfoList = imageStub.createImageInfoList(1, true);
 
-        MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName, fileName.concat(".").concat(ext), ext, fileInputStream1);
-        MockMultipartFile mockMultipartFile2 = new MockMultipartFile(fileName, fileName.concat(".").concat(ext), ext, fileInputStream2);
+        Review postReview = reviewStub.createReview(userId, itemId, reviewId);
+        List<ReviewImage> reviewImage = imageStub.createReviewImage(postReview);
 
-        fileList.add(mockMultipartFile);
-        fileList.add(mockMultipartFile2);
-
-        ReviewPostRequestDto reviewPostRequestDto = reviewStub.reviewPostRequestDto(userId);
-        Review savedReview = reviewStub.createReview(userId, itemId, reviewId);
-        given(reviewRepository.save(ArgumentMatchers.any(Review.class))).willReturn(savedReview);
+        Review excepted = reviewStub.createReview(userId, itemId, reviewId,reviewImage);
+        given(reviewRepository.save(ArgumentMatchers.any(Review.class))).willReturn(excepted);
         given(fileUploader.uploadImage(ArgumentMatchers.anyList())).willReturn(imageStub.createImageList(2));
 
-        ReviewIdResponseDto result = reviewService.postReview(reviewPostRequestDto, userId, itemId, fileList);
-
+        Review result = reviewService.postReview(imageInfoList, postReview, userId, itemId);
         SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(result.getReviewId()).as("리뷰 Id는 생성되는 리뷰 Id와 일치해야합니다.").isEqualTo(reviewId);
-            softAssertions.assertThat(result.getUserId()).as("사용자 Id는 요청 시 받는 사용자 Id 와 일치 해야합니다.").isEqualTo(userId);
-            softAssertions.assertThat(result.getItemId()).as("아이템 Id는 요청 시 받는 아이템 Id 와 일치 해야합니다.").isEqualTo(itemId);
+            softAssertions.assertThat(result.getUser().getId()).as("review의 User엔티티의 id틑 post 받은 것과 동일해야합니다.").isEqualTo(userId);
+            softAssertions.assertThat(result.getItem().getId()).as("review의 Item엔티티의 id틑 post 받은 것과 동일해야합니다.").isEqualTo(userId);
+            softAssertions.assertThat(result.getReviewImageList()).as("저장된 이미지의 정보 일치 여부 체크").isEqualTo(excepted.getReviewImageList());
         });
     }
 
-
     @Test
-    @DisplayName("리뷰 작성 : 예외 발생, 사진과 사진 정렬 정보 가진 리스트의 수가 다를때")
-    void postReviewExceptionUserValidTest() throws IOException {
-        String fileName = "testImage";
-        String ext = "png";
-        String path = "src/test/resources/image/testImage.png";
-        FileInputStream fileInputStream1 = new FileInputStream(new File(path));
-        List<MultipartFile> fileList = new ArrayList<>();
+    @DisplayName("리뷰 작성 : 예외 발생, 대표 사진 미설정")
+    void postReviewExceptionValidTest() throws IOException {
+        List<ImageInfoDto> imageInfoList = imageStub.createImageInfoList(1, false);
+        Review postReview = reviewStub.createReview(userId, itemId, reviewId);
+        Throwable exception = catchThrowable(() -> reviewService.postReview(imageInfoList,postReview, userId, itemId));
 
-        MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName, fileName.concat(".").concat(ext), ext, fileInputStream1);
-        fileList.add(mockMultipartFile);
-
-        ReviewPostRequestDto reviewPostRequestDto = reviewStub.reviewPostRequestDto(userId);
-        Throwable exception = catchThrowable(() -> reviewService.postReview(reviewPostRequestDto, userId, itemId, fileList));
-
-
-        Assertions.assertThat(exception).as("저장 파일과 해당 정보의 수를 일치 시키지 않으면 예외가 발생합니다.")
+        Assertions.assertThat(exception).as("1개의 대표사진을 필수로 설정해야 됩니다.")
                 .isInstanceOf(BusinessLogicException.class)
-                .hasMessage("이미지와 정보의 수가 일치하지 않습니다.");
+                .hasMessage("대표 이미지가 한개 있어야합니다.");
+
+
+    }
+    @Test
+    @DisplayName("리뷰 작성 : 예외 발생, 사진의 정렬 순서 중복 발생 예외")
+    void postReviewExceptionValidTest2() throws IOException {
+        List<ImageInfoDto> imageInfoList = imageStub.createImageInfoList(0, true);
+        Review postReview = reviewStub.createReview(userId, itemId, reviewId);
+        Throwable exception = catchThrowable(() -> reviewService.postReview(imageInfoList,postReview, userId, itemId));
+
+        Assertions.assertThat(exception).as("사진 정렬 순서는 중복될 수 없습니다.")
+                .isInstanceOf(BusinessLogicException.class)
+                .hasMessage("이미지 순서는 중복될 수 없습니다.");
+
+
+
     }
     @Test
     @DisplayName("리뷰 수정 사진 제외 수정 : 성공")
-    void updateReviewNoImageTest() throws IOException {
-        String fileName = "testImage";
-        String ext = "png";
-        String path = "src/test/resources/image/testImage.png";
-        FileInputStream fileInputStream1 = new FileInputStream(new File(path));
-        FileInputStream fileInputStream2 = new FileInputStream(new File(path));
-        ReviewUpdateRequestDto requestDto = reviewStub.reviewUpdateRequestDto(userId, true);
+    void updateReviewNoImageTest(){
 
-        List<MultipartFile> fileList = new ArrayList<>();
-
-        MockMultipartFile mockMultipartFile = new MockMultipartFile(fileName, fileName.concat(".").concat(ext), ext, fileInputStream1);
-        MockMultipartFile mockMultipartFile2 = new MockMultipartFile(fileName, fileName.concat(".").concat(ext), ext, fileInputStream2);
-
-        fileList.add(mockMultipartFile);
-        fileList.add(mockMultipartFile2);
-
-
-        Review findReview = reviewStub.createReview(userId, itemId, reviewId);
-        List<ReviewImage> reviewImage = imageStub.createReviewImage(findReview);
-
-        given(reviewValidService.validReview(ArgumentMatchers.anyLong())).willReturn(findReview);
-        willDoNothing().given(fileUploader).deleteS3Image(ArgumentMatchers.anyString());
-        given(fileUploader.uploadImage(ArgumentMatchers.anyList())).willReturn(imageStub.createImageList(2));
-
-        //when
-        ReviewIdResponseDto result = reviewService.updateReview(requestDto, fileList, userId, itemId, reviewId);
-
-        SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(result.getReviewId()).as("리뷰 Id는 생성되는 리뷰 Id와 일치해야합니다.").isEqualTo(reviewId);
-            softAssertions.assertThat(result.getUserId()).as("사용자 Id는 요청 시 받는 사용자 Id 와 일치 해야합니다.").isEqualTo(userId);
-            softAssertions.assertThat(result.getItemId()).as("아이템 Id는 요청 시 받는 아이템 Id 와 일치 해야합니다.").isEqualTo(itemId);
-        });
     }
 
     @Test

--- a/BE/backend/src/test/java/project/main/webstore/domain/review/stub/ReviewStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/review/stub/ReviewStub.java
@@ -67,19 +67,19 @@ public class ReviewStub {
         return ReviewPostRequestDto.stubBuilder().userId(userId).infoList(null).comment("사진이 없는 리뷰").rating(10).stubBuild();
     }
 
-    public ReviewPostRequestDto reviewPostRequestDto(Long userId) {
-        return ReviewPostRequestDto.stubBuilder().userId(userId).infoList(imageSortListDto()).comment("사진이 없는 리뷰").rating(10).stubBuild();
+    public ReviewPostRequestDto reviewPostRequestDto(Long userId,boolean target) {
+        return ReviewPostRequestDto.stubBuilder().userId(userId).infoList(imageSortListDto(target)).comment("사진이 없는 리뷰").rating(10).stubBuild();
     }
 
     public ReviewUpdateRequestDto reviewUpdateRequestDto(Long userId,boolean target) {
-        return new ReviewUpdateRequestDto(userId, "이것은 수정입니다.", 5, List.of(1L), imageSortPatchInfoList(target));
+        return new ReviewUpdateRequestDto(userId, "이것은 수정입니다.", 5, List.of(1L), imageSortListDto(target));
     }
 
     //이미지단 이동
-    public List<ImageSortDto> imageSortListDto() {
+    public List<ImageSortDto> imageSortListDto(boolean target) {
         return Stream.of(
                 imageSortDto(0, false),
-                imageSortDto(1, true)
+                imageSortDto(1, target)
         ).collect(Collectors.toList());
     }
 

--- a/BE/backend/src/test/java/project/main/webstore/stub/ImageStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/stub/ImageStub.java
@@ -1,5 +1,8 @@
 package project.main.webstore.stub;
 
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import project.main.webstore.domain.image.dto.ImageInfoDto;
 import project.main.webstore.domain.image.entity.Image;
 import project.main.webstore.domain.image.entity.ReviewImage;
 import project.main.webstore.domain.review.entity.Review;
@@ -7,32 +10,64 @@ import project.main.webstore.domain.review.entity.Review;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ImageStub {
     private String fileName = "testImage";
     private String ext = "png";
     private String path = "src/test/resources/image/testImage";
+    private byte[] content = "This is Mock Image".getBytes();
+
+    private MockMultipartFile mockMultipartFile;
+    private MockMultipartFile mockMultipartFile2;
+    private List<MultipartFile> fileList = new ArrayList<>();
+
+    public ImageStub(){
+            fileList = new ArrayList<>();
+            mockMultipartFile = new MockMultipartFile(fileName, fileName.concat(".").concat(ext), ext, content);
+            mockMultipartFile2 = new MockMultipartFile(fileName, fileName.concat(".").concat(ext), ext, content);
+            fileList.add(mockMultipartFile);
+            fileList.add(mockMultipartFile2);
+
+    }
 
     public Image createImage(int order, boolean representative) {
         return new Image(fileName + order, "업로드 네임", path + order + "." + ext, ext, path + order + "." + ext, order, representative, "해쉬 코드가 들어올 자리");
     }
-    public Image createImage(Long id,int order, boolean representative) {
-        return new Image(id,fileName + order, "업로드 네임", path + order + "." + ext, ext, path + order + "." + ext, order, representative, "해쉬 코드가 들어올 자리");
+
+    public Image createImage(Long id, int order, boolean representative) {
+        return new Image(id, fileName + order, "업로드 네임", path + order + "." + ext, ext, path + order + "." + ext, order, representative, "해쉬 코드가 들어올 자리");
     }
 
     public List<Image> createImageList(int idx) {
         List<Image> list = new ArrayList<>();
         for (int i = 0; i < idx; i++) {
             boolean representative = i == 1;
-            list.add(createImage((long)i,i, representative));
+            list.add(createImage((long) i, i, representative));
         }
         return list;
     }
-
 
     public List<ReviewImage> createReviewImage(Review review) {
         List<ReviewImage> reviewImageList = createImageList(2).stream().map(image -> new ReviewImage(image, review)).collect(Collectors.toList());
         review.setReviewImageList(reviewImageList);
         return reviewImageList;
+    }
+
+    public ImageInfoDto createImageInfoDto(int order, boolean target) {
+        return ImageInfoDto.dtoBuilder()
+                .uploadDir("review")
+                .representative(target)
+                .order(order)
+                .multipartFile(mockMultipartFile)
+                .build();
+    }
+
+    public List<ImageInfoDto> createImageInfoList(int order, boolean target) {
+        return Stream.of(
+                createImageInfoDto(0, false),
+                createImageInfoDto(order, target)
+
+        ).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
# 작업 내용
<img width="648" alt="image" src="https://github.com/devstoreproject/devstore/assets/116015708/04a722f0-497b-4899-8ba2-3def565f09b9">

* 위에 있는 Request, Response 방식을 아래에 있는 방식으로 변경

# 변경 이유
1. 계층간의 결합도 약화
      * 요청으로 받은 dto를 그대로 사용했던 기존의 코드에서 **Entity or 내부 사용 dto 변경으로 인한 결합도 약화**
2. Service단에서 너무 많은 작업을 진행함
      * 기존의 코드는 dto ->Entity -> dto , 서비스 로직 까지 모두 서비스단에서 처리 하기 때문에 서비스단의 역할이 너무 많아 역할 분산
      * 서비스단은 서비스 코드만 만들 수 있게 구현
3. 이미지의 경우는 내부 사용 dto로 변경해 사용

# 고민 사항
1. 너무 많은 변환이 이루어진다는 생각이 든다.
2. OSIV 사용 시 트랜잭션에서 DB에 있는 모든 데이터를 가져와야되는데 dto 변환을 Service에서 하는것이 좋지 않을까 하는 고민
3. Image의 경우는 내부 사용 dto를 만들어서 사용하고 있는데 이것도 entity로 바꾸는게 좋을지 고민