### PR TITLE
reviewGetService 계층간 의존성 약화

### DIFF
--- a/BE/backend/src/main/java/project/main/webstore/domain/image/dto/ImageLocalDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/image/dto/ImageLocalDto.java
@@ -1,0 +1,41 @@
+package project.main.webstore.domain.image.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Setter
+@Getter
+public class ImageLocalDto {
+    private Long imageId;
+    private MultipartFile multipartFile;
+    private MultipartFile thumbFile;
+    private int order;
+    private boolean representative;
+    private String hash;
+    private String uploadDir;
+    private String originalName;
+    private String uploadName;
+    private String fileName;
+    private String ext;
+    @Builder(builderMethodName = "dtoBuilder")
+    public ImageLocalDto(MultipartFile multipartFile,Long id, int order, boolean representative, String uploadDir) {
+        this.imageId = id;
+        this.multipartFile = multipartFile;
+        this.order = order;
+        this.representative = representative;
+        this.uploadDir = uploadDir;
+        this.originalName = multipartFile.getOriginalFilename();
+        this.ext = extractExt(originalName);
+        this.uploadName = UUID.randomUUID().toString().concat(ext);
+        this.fileName = uploadDir.concat("/").concat(uploadDir);
+    }
+
+    private String extractExt(String originalFileName) {
+        int idx = originalFileName.lastIndexOf(".");
+        return originalFileName.substring(idx);
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/controller/ReviewController.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/controller/ReviewController.java
@@ -1,0 +1,105 @@
+package project.main.webstore.domain.review.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import project.main.webstore.domain.image.dto.ImageInfoDto;
+import project.main.webstore.domain.image.mapper.ImageMapper;
+import project.main.webstore.domain.review.dto.ReviewGetResponseDto;
+import project.main.webstore.domain.review.dto.ReviewIdResponseDto;
+import project.main.webstore.domain.review.dto.ReviewPostRequestDto;
+import project.main.webstore.domain.review.dto.ReviewUpdateRequestDto;
+import project.main.webstore.domain.review.entity.Review;
+import project.main.webstore.domain.review.mapper.ReviewMapper;
+import project.main.webstore.domain.review.service.ReviewGetService;
+import project.main.webstore.domain.review.service.ReviewService;
+import project.main.webstore.dto.ResponseDto;
+import project.main.webstore.enums.ResponseCode;
+import project.main.webstore.utils.UriCreator;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ReviewController {
+    private final String UPLOAD_DIR = "review";
+    private final ReviewGetService getService;
+    private final ReviewService service;
+    private final ReviewMapper reviewMapper;
+    private final ImageMapper imageMapper;
+    @PostMapping("/item/{itemId}/review")
+    public ResponseEntity postReview(@PathVariable Long itemId,
+                                     @RequestPart ReviewPostRequestDto postDto,
+                                     @RequestPart(required = false) List<MultipartFile> imageList){
+        Review review = reviewMapper.toEntity(postDto);
+
+        Review savedReview;
+        if (imageList == null) {
+            savedReview = service.postReview(review, postDto.getUserId(), itemId);
+        } else {
+            List<ImageInfoDto> imageInfoDtoList = imageMapper.toLocalDtoList(imageList, postDto.getInfoList(), UPLOAD_DIR);
+            savedReview = service.postReview(imageInfoDtoList,review,postDto.getUserId(),itemId);
+        }
+
+        ReviewIdResponseDto response = reviewMapper.toDto(savedReview);
+        var responseDto = ResponseDto.<ReviewIdResponseDto>builder().data(response).customCode(ResponseCode.CREATED).build();
+        URI uri = UriCreator.createUri("/api/item", "/review", itemId, responseDto.getData().getReviewId());
+        return ResponseEntity.created(uri).body(responseDto);
+    }
+
+    @GetMapping("/review/{reviewId}")
+    public ResponseEntity getReview(@PathVariable Long reviewId) {
+        ReviewGetResponseDto response = getService.getReviewByReviewId(reviewId);
+        var responseDto = ResponseDto.<ReviewGetResponseDto>builder()
+                .data(response)
+                .customCode(ResponseCode.OK)
+                .build();
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/review")
+    public ResponseEntity getReviewAllPage(Pageable pageable,Long userId) {
+        getService.getReviewPage(userId,pageable);
+        return null;
+    }
+    @GetMapping("/item/{itemId}/review")
+    public ResponseEntity getReviewPageByItemId(Pageable pageable, @PathVariable Long itemId) {
+        getService.getReviewPageByItemId(pageable,itemId);
+        return null;
+
+    }
+    @GetMapping("/user/{userId}/review")
+    public ResponseEntity getReviewListByUserId(Pageable pageable,@PathVariable Long userId) {
+        getService.getReviewPageByUserId(pageable,userId);
+        return null;
+
+    }
+
+    @DeleteMapping("/item/{itemId}/review/{reviewId}")
+    public ResponseEntity deleteReview(@PathVariable Long itemId,
+                                       @PathVariable Long reviewId
+                                       ){
+        service.deleteReview(reviewId);
+        return ResponseEntity.ok(ResponseDto.builder().data(null).customCode(ResponseCode.OK).build());
+    }
+
+    @PatchMapping("/item/{itemId}/review/{reviewId}")
+    public ResponseEntity patchReview(@PathVariable Long itemId,
+                                      @PathVariable Long reviewId,
+                                      @RequestPart ReviewUpdateRequestDto patchDto,
+                                      @RequestPart List<MultipartFile> imageList
+                                      ){
+        Review review = reviewMapper.toEntity(patchDto, reviewId);
+        List<ImageInfoDto> imageInfoList = imageMapper.toLocalDtoList(imageList, patchDto.getImageSortAndRepresentativeInfo(), UPLOAD_DIR);
+        Review patchReview = service.patchReview(imageInfoList,patchDto.getDeleteImageId(),review, patchDto.getUserId(), itemId, reviewId);
+        ReviewIdResponseDto reviewIdResponseDto = reviewMapper.toDto(patchReview);
+        var responseDto = ResponseDto.<ReviewIdResponseDto>builder().data(reviewIdResponseDto).customCode(ResponseCode.OK).build();
+
+        URI uri = UriCreator.createUri("/api/item", "/review", itemId, responseDto.getData().getReviewId());
+        return ResponseEntity.ok().header("Location",uri.toString()).body(responseDto);
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/mapper/ReviewMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/mapper/ReviewMapper.java
@@ -39,17 +39,17 @@ public class ReviewMapper {
         return new ReviewIdResponseDto(review.getId(),review.getUser().getId(),review.getItem().getId());
     }
 
-    public ReviewGetResponseDto reviewGetResponse(Review review){
+    public ReviewGetResponseDto toGetDtoResponse(Review review){
         return ReviewGetResponseDto.dtoBuilder()
                 .review(review)
                 .dtoBuild();
     }
 
-    public Page<ReviewGetResponseDto> reviewGetPageResponse(Page<Review> reviewPage){
+    public Page<ReviewGetResponseDto> toGetPageResponse(Page<Review> reviewPage){
         return reviewPage.map(ReviewGetResponseDto::new);
     }
 
-    public Slice<ReviewGetResponseDto> reviewGetSliceResponse(Slice<Review> reviewSlice){
+    public Slice<ReviewGetResponseDto> toGetSliceResponse(Slice<Review> reviewSlice){
         return reviewSlice.map(ReviewGetResponseDto::new);
     }
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewGetService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewGetService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.review.entity.Review;
-import project.main.webstore.domain.review.mapper.ReviewMapper;
 import project.main.webstore.domain.review.repository.ReviewRepository;
 import project.main.webstore.domain.users.entity.User;
 
@@ -17,7 +16,6 @@ import project.main.webstore.domain.users.entity.User;
 public class ReviewGetService {
     private final ReviewRepository reviewRepository;
     private final ReviewValidService reviewValidService;
-    private final ReviewMapper mapper;
 
     public Review getReviewByReviewId(Long reviewId) {
         Review findReview = reviewValidService.validReview(reviewId);
@@ -28,8 +26,7 @@ public class ReviewGetService {
     }
 
 
-
-    public Page<Review> getReviewPage(Long userId,Pageable pageable){
+    public Page<Review> getReviewPage(Long userId, Pageable pageable) {
         //TODO UserId를 이용해 검증할 필요가 있다. 관리자가 맞는지 검증할 필요가 있다.
         Page<Review> reviewPage = reviewRepository.findAllPage(pageable);
         return reviewPage;

--- a/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewGetService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/review/service/ReviewGetService.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.main.webstore.domain.item.entity.Item;
-import project.main.webstore.domain.review.dto.ReviewGetResponseDto;
 import project.main.webstore.domain.review.entity.Review;
 import project.main.webstore.domain.review.mapper.ReviewMapper;
 import project.main.webstore.domain.review.repository.ReviewRepository;
@@ -20,40 +19,31 @@ public class ReviewGetService {
     private final ReviewValidService reviewValidService;
     private final ReviewMapper mapper;
 
-    public ReviewGetResponseDto getReviewByReviewId(Long reviewId) {
+    public Review getReviewByReviewId(Long reviewId) {
         Review findReview = reviewValidService.validReview(reviewId);
         //추 후 삭제
         findReview.setUser(new User(1L));
         findReview.setItem(new Item(1L));
-        return mapper.reviewGetResponse(findReview);
-    }
-
-    public ReviewGetResponseDto getReviewByUserId(Long userId, Long reviewId) {
-        Review findReview = reviewValidService.validReviewByUserId(userId, reviewId);
-        return mapper.reviewGetResponse(findReview);
-    }
-
-    public ReviewGetResponseDto getReviewByItemId(Long itemId, Long reviewId) {
-        Review findReview = reviewValidService.validReviewByItemId(itemId, reviewId);
-        return mapper.reviewGetResponse(findReview);
+        return findReview;
     }
 
 
-    public Page<ReviewGetResponseDto> getReviewPage(Long userId,Pageable pageable){
+
+    public Page<Review> getReviewPage(Long userId,Pageable pageable){
         //TODO UserId를 이용해 검증할 필요가 있다. 관리자가 맞는지 검증할 필요가 있다.
         Page<Review> reviewPage = reviewRepository.findAllPage(pageable);
-        return mapper.reviewGetPageResponse(reviewPage);
+        return reviewPage;
     }
 
-    public Page<ReviewGetResponseDto> getReviewPageByUserId(Pageable pageable, Long userId) {
+    public Page<Review> getReviewPageByUserId(Pageable pageable, Long userId) {
         //TODO User 검증 필요
         Page<Review> reviewPage = reviewRepository.findByUserIdPage(pageable, userId);
-        return mapper.reviewGetPageResponse(reviewPage);
+        return reviewPage;
     }
 
-    public Page<ReviewGetResponseDto> getReviewPageByItemId(Pageable pageable, Long itemId) {
+    public Page<Review> getReviewPageByItemId(Pageable pageable, Long itemId) {
         //TODO Item 검증 필요
         Page<Review> reviewPage = reviewRepository.findByItemIdPage(pageable, itemId);
-        return mapper.reviewGetPageResponse(reviewPage);
+        return reviewPage;
     }
 }

--- a/BE/backend/src/main/java/project/main/webstore/enums/ResponseCode.java
+++ b/BE/backend/src/main/java/project/main/webstore/enums/ResponseCode.java
@@ -6,7 +6,7 @@ import project.main.webstore.dto.CustomCode;
 @Getter
 public enum ResponseCode implements CustomCode {
 
-    ;
+    CREATED, OK;
 
     private String code;
     private String message;

--- a/BE/backend/src/main/java/project/main/webstore/utils/UriCreator.java
+++ b/BE/backend/src/main/java/project/main/webstore/utils/UriCreator.java
@@ -1,0 +1,23 @@
+package project.main.webstore.utils;
+
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+public class UriCreator {
+    public static URI createUri(String defaultUrl1,String defaultUrl2, long resourceId1,long reviewId2) {
+        return UriComponentsBuilder
+                .newInstance()
+                .path(defaultUrl1 + "/{resource-id1}" + defaultUrl2 + "/{resource-id2}")
+                .buildAndExpand(resourceId1,reviewId2)
+                .toUri();
+    }
+
+    public static URI createUri(String defaultUrl) {
+        return UriComponentsBuilder
+                .newInstance()
+                .path(defaultUrl)
+                .build()
+                .toUri();
+    }
+}

--- a/BE/backend/src/test/java/project/main/webstore/domain/review/service/ReviewGetServiceTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/review/service/ReviewGetServiceTest.java
@@ -14,12 +14,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import project.main.webstore.domain.review.dto.ReviewGetResponseDto;
 import project.main.webstore.domain.review.entity.Review;
-import project.main.webstore.domain.review.mapper.ReviewMapper;
 import project.main.webstore.domain.review.repository.ReviewRepository;
 import project.main.webstore.domain.review.stub.ReviewStub;
 import project.main.webstore.exception.BusinessLogicException;
 
-import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,8 +28,6 @@ class ReviewGetServiceTest {
     private ReviewRepository reviewRepository;
     @Mock
     private ReviewValidService reviewValidService;
-    @Mock
-    private ReviewMapper reviewMapper;
     private ReviewStub reviewStub = new ReviewStub();
 
     private Long reviewId = 1L;
@@ -46,7 +42,6 @@ class ReviewGetServiceTest {
         ReviewGetResponseDto expected = reviewStub.reviewGetResponseDto(review);
 
         given(reviewValidService.validReview(ArgumentMatchers.anyLong())).willReturn(review);
-        given(reviewMapper.toGetDtoResponse(ArgumentMatchers.any(Review.class))).willReturn(expected);
         // when
         Review result = reviewGetService.getReviewByReviewId(reviewId);
         // then
@@ -70,55 +65,49 @@ class ReviewGetServiceTest {
         int page = 0;
         int size = 3;
         Page<Review> reviewPage = reviewStub.createPageReview(page, size);
-        Page<ReviewGetResponseDto> expected = reviewStub.reviewGetResponseDtoPage(page, size);
         PageRequest pageInfo = PageRequest.of(0, 3);
         // given
         BDDMockito.given(reviewRepository.findAllPage(ArgumentMatchers.any(Pageable.class))).willReturn(reviewPage);
-        BDDMockito.given(reviewMapper.toGetPageResponse(any(Page.class))).willReturn(expected);
 
         // when
-        Page<Review> result = reviewGetService.getReviewPage(userId,pageInfo);
+        Page<Review> result = reviewGetService.getReviewPage(userId, pageInfo);
         // then
-        Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparator().isEqualTo(expected);
+        Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparator().isEqualTo(reviewPage);
         Assertions.assertThat(result.getSize()).isEqualTo(size);
     }
 
     @Test
     @DisplayName("userId 이용한 리뷰 전체 조회(페이지) : 성공")
-    void getReviewPageByUserIdTest() throws Exception{
+    void getReviewPageByUserIdTest() throws Exception {
         int page = 0;
         int size = 3;
         Page<Review> reviewPage = reviewStub.createPageReview(page, size);
-        Page<ReviewGetResponseDto> expected = reviewStub.reviewGetResponseDtoPage(page, size);
         PageRequest pageInfo = PageRequest.of(0, 3);
         // given
         BDDMockito.given(reviewRepository.findByUserIdPage(ArgumentMatchers.any(Pageable.class), ArgumentMatchers.anyLong())).willReturn(reviewPage);
-        BDDMockito.given(reviewMapper.toGetPageResponse(any(Page.class))).willReturn(expected);
 
         // when
         Page<Review> result = reviewGetService.getReviewPageByUserId(pageInfo, userId);
         // then
-        Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparator().isEqualTo(expected);
+        Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparator().isEqualTo(reviewPage);
         Assertions.assertThat(result.getSize()).isEqualTo(size);
 
     }
 
     @Test
     @DisplayName("itemId 이용한 리뷰 전체 조회(페이지) : 성공")
-    void getReviewPageByItemIdTest() throws Exception{
+    void getReviewPageByItemIdTest() throws Exception {
         int page = 0;
         int size = 3;
         Page<Review> reviewPage = reviewStub.createPageReview(page, size);
-        Page<ReviewGetResponseDto> expected = reviewStub.reviewGetResponseDtoPage(page, size);
         PageRequest pageInfo = PageRequest.of(0, 3);
         // given
         BDDMockito.given(reviewRepository.findByItemIdPage(ArgumentMatchers.any(Pageable.class), ArgumentMatchers.anyLong())).willReturn(reviewPage);
-        BDDMockito.given(reviewMapper.toGetPageResponse(any(Page.class))).willReturn(expected);
 
         // when
         Page<Review> result = reviewGetService.getReviewPageByItemId(pageInfo, itemId);
         // then
-        Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparator().isEqualTo(expected);
+        Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparator().isEqualTo(reviewPage);
         Assertions.assertThat(result.getSize()).isEqualTo(size);
     }
 }

--- a/BE/backend/src/test/java/project/main/webstore/domain/review/service/ReviewGetServiceTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/review/service/ReviewGetServiceTest.java
@@ -46,14 +46,13 @@ class ReviewGetServiceTest {
         ReviewGetResponseDto expected = reviewStub.reviewGetResponseDto(review);
 
         given(reviewValidService.validReview(ArgumentMatchers.anyLong())).willReturn(review);
-        given(reviewMapper.reviewGetResponse(ArgumentMatchers.any(Review.class))).willReturn(expected);
+        given(reviewMapper.toGetDtoResponse(ArgumentMatchers.any(Review.class))).willReturn(expected);
         // when
-        ReviewGetResponseDto result = reviewGetService.getReviewByReviewId(reviewId);
+        Review result = reviewGetService.getReviewByReviewId(reviewId);
         // then
-        Assertions.assertThat(result.getReviewId()).isEqualTo(review.getId());
-        Assertions.assertThat(result.getItemId()).isEqualTo(review.getItem().getId());
-        Assertions.assertThat(result.getUserId()).isEqualTo(review.getUser().getId());
-        Assertions.assertThat(result.getReviewId()).as("assertion 수행 이전에 넣어줘야한다.즉 맨 마지막에 나오면 에러 터짐 ㅎㅎ").isEqualTo(reviewId);
+        Assertions.assertThat(result.getItem().getId()).isEqualTo(review.getItem().getId());
+        Assertions.assertThat(result.getUser().getId()).isEqualTo(review.getUser().getId());
+        Assertions.assertThat(result.getId()).as("assertion 수행 이전에 넣어줘야한다.즉 맨 마지막에 나오면 에러 터짐 ㅎㅎ").isEqualTo(reviewId);
     }
 
     @Test
@@ -75,10 +74,10 @@ class ReviewGetServiceTest {
         PageRequest pageInfo = PageRequest.of(0, 3);
         // given
         BDDMockito.given(reviewRepository.findAllPage(ArgumentMatchers.any(Pageable.class))).willReturn(reviewPage);
-        BDDMockito.given(reviewMapper.reviewGetPageResponse(any(Page.class))).willReturn(expected);
+        BDDMockito.given(reviewMapper.toGetPageResponse(any(Page.class))).willReturn(expected);
 
         // when
-        Page<ReviewGetResponseDto> result = reviewGetService.getReviewPage(userId,pageInfo);
+        Page<Review> result = reviewGetService.getReviewPage(userId,pageInfo);
         // then
         Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparator().isEqualTo(expected);
         Assertions.assertThat(result.getSize()).isEqualTo(size);
@@ -94,10 +93,10 @@ class ReviewGetServiceTest {
         PageRequest pageInfo = PageRequest.of(0, 3);
         // given
         BDDMockito.given(reviewRepository.findByUserIdPage(ArgumentMatchers.any(Pageable.class), ArgumentMatchers.anyLong())).willReturn(reviewPage);
-        BDDMockito.given(reviewMapper.reviewGetPageResponse(any(Page.class))).willReturn(expected);
+        BDDMockito.given(reviewMapper.toGetPageResponse(any(Page.class))).willReturn(expected);
 
         // when
-        Page<ReviewGetResponseDto> result = reviewGetService.getReviewPageByUserId(pageInfo, userId);
+        Page<Review> result = reviewGetService.getReviewPageByUserId(pageInfo, userId);
         // then
         Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparator().isEqualTo(expected);
         Assertions.assertThat(result.getSize()).isEqualTo(size);
@@ -114,10 +113,10 @@ class ReviewGetServiceTest {
         PageRequest pageInfo = PageRequest.of(0, 3);
         // given
         BDDMockito.given(reviewRepository.findByItemIdPage(ArgumentMatchers.any(Pageable.class), ArgumentMatchers.anyLong())).willReturn(reviewPage);
-        BDDMockito.given(reviewMapper.reviewGetPageResponse(any(Page.class))).willReturn(expected);
+        BDDMockito.given(reviewMapper.toGetPageResponse(any(Page.class))).willReturn(expected);
 
         // when
-        Page<ReviewGetResponseDto> result = reviewGetService.getReviewPageByItemId(pageInfo, itemId);
+        Page<Review> result = reviewGetService.getReviewPageByItemId(pageInfo, itemId);
         // then
         Assertions.assertThat(result).usingRecursiveFieldByFieldElementComparator().isEqualTo(expected);
         Assertions.assertThat(result.getSize()).isEqualTo(size);


### PR DESCRIPTION
# 작업 내용
<img width="648" alt="image" src="https://github.com/devstoreproject/devstore/assets/116015708/04a722f0-497b-4899-8ba2-3def565f09b9">

* 위에 있는 Request, Response 방식을 아래에 있는 방식으로 변경

# 변경 이유
1. 계층간의 결합도 약화
      * 요청으로 받은 dto를 그대로 사용했던 기존의 코드에서 **Entity or 내부 사용 dto 변경으로 인한 결합도 약화**
2. Service단에서 너무 많은 작업을 진행함
      * 기존의 코드는 dto ->Entity -> dto , 서비스 로직 까지 모두 서비스단에서 처리 하기 때문에 서비스단의 역할이 너무 많아 역할 분산
      * 서비스단은 서비스 코드만 만들 수 있게 구현
3. 이미지의 경우는 내부 사용 dto로 변경해 사용

# 고민 사항
1. 너무 많은 변환이 이루어진다는 생각이 든다.
2. OSIV 사용 시 트랜잭션에서 DB에 있는 모든 데이터를 가져와야되는데 dto 변환을 Service에서 하는것이 좋지 않을까 하는 고민
3. Image의 경우는 내부 사용 dto를 만들어서 사용하고 있는데 이것도 entity로 바꾸는게 좋을지 고민