### PR TITLE
Notice Controller 구현 완료

### DIFF
--- a/BE/backend/src/main/java/project/main/webstore/domain/notice/controller/NoticeController.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/notice/controller/NoticeController.java
@@ -1,0 +1,75 @@
+package project.main.webstore.domain.notice.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import project.main.webstore.domain.image.dto.ImageInfoDto;
+import project.main.webstore.domain.image.mapper.ImageMapper;
+import project.main.webstore.domain.notice.dto.NoticeIdResponseDto;
+import project.main.webstore.domain.notice.dto.NoticePatchRequestDto;
+import project.main.webstore.domain.notice.dto.NoticePostRequestDto;
+import project.main.webstore.domain.notice.entity.Notice;
+import project.main.webstore.domain.notice.mapper.NoticeMapper;
+import project.main.webstore.domain.notice.service.NoticeGetService;
+import project.main.webstore.domain.notice.service.NoticeService;
+import project.main.webstore.dto.ResponseDto;
+import project.main.webstore.enums.ResponseCode;
+import project.main.webstore.utils.UriCreator;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notice")
+@RequiredArgsConstructor
+public class NoticeController {
+    private final String UPLOAD_DIR = "notice";
+    private final NoticeService service;
+    private final NoticeGetService getService;
+    private final NoticeMapper noticeMapper;
+    private final ImageMapper imageMapper;
+
+    @PostMapping
+    public ResponseEntity postNotice(@RequestPart(required = false) List<MultipartFile> imageList,
+                                     @RequestPart NoticePostRequestDto postDto) {
+        Notice requsetNotice = noticeMapper.toEntity(postDto);
+        Notice responseNotice;
+        if (imageList != null) {
+            List<ImageInfoDto> infoList = imageMapper.toLocalDtoList(imageList, postDto.getInfoList(), UPLOAD_DIR);
+            responseNotice = service.postNotice(requsetNotice, infoList, postDto.getUserId());
+        } else {
+            responseNotice = service.postNotice(requsetNotice, postDto.getUserId());
+        }
+        NoticeIdResponseDto response = noticeMapper.toResponseDto(responseNotice);
+        URI uri = UriCreator.createUri(UPLOAD_DIR, responseNotice.getId());
+        var responseDto = ResponseDto.<NoticeIdResponseDto>builder().data(response).customCode(ResponseCode.CREATED).build();
+
+
+        return ResponseEntity.created(uri).body(responseDto);
+    }
+
+    @PatchMapping("/{noticeId}")
+    public ResponseEntity patchNotice(@PathVariable Long noticeId,
+                                      @RequestPart(required = false) List<MultipartFile> imageList,
+                                      @RequestPart NoticePatchRequestDto patchDto) {
+        Notice notice = noticeMapper.toEntity(patchDto,noticeId);
+        List<ImageInfoDto> infoList = imageMapper.toLocalDtoList(imageList, patchDto.getImageSortAndRepresentativeInfo(), UPLOAD_DIR);
+
+        Notice responseNotice = service.patchNotice(infoList, patchDto.getDeleteImageId(), notice, patchDto.getUserId());
+
+        NoticeIdResponseDto response = noticeMapper.toResponseDto(responseNotice);
+        URI uri = UriCreator.createUri(UPLOAD_DIR, responseNotice.getId());
+        var responseDto = ResponseDto.<NoticeIdResponseDto>builder().data(response).customCode(ResponseCode.OK).build();
+
+        return ResponseEntity.ok().header("Location",uri.toString()).body(responseDto);
+    }
+
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity deleteNotice(@PathVariable Long noticeId) {
+        service.deleteNotice(noticeId);
+        var responseDto = ResponseDto.builder().data(null).customCode(ResponseCode.OK).build();
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/notice/controller/NoticeController.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/notice/controller/NoticeController.java
@@ -1,14 +1,14 @@
 package project.main.webstore.domain.notice.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import project.main.webstore.domain.image.dto.ImageInfoDto;
 import project.main.webstore.domain.image.mapper.ImageMapper;
-import project.main.webstore.domain.notice.dto.NoticeIdResponseDto;
-import project.main.webstore.domain.notice.dto.NoticePatchRequestDto;
-import project.main.webstore.domain.notice.dto.NoticePostRequestDto;
+import project.main.webstore.domain.notice.dto.*;
 import project.main.webstore.domain.notice.entity.Notice;
 import project.main.webstore.domain.notice.mapper.NoticeMapper;
 import project.main.webstore.domain.notice.service.NoticeGetService;
@@ -53,7 +53,7 @@ public class NoticeController {
     public ResponseEntity patchNotice(@PathVariable Long noticeId,
                                       @RequestPart(required = false) List<MultipartFile> imageList,
                                       @RequestPart NoticePatchRequestDto patchDto) {
-        Notice notice = noticeMapper.toEntity(patchDto,noticeId);
+        Notice notice = noticeMapper.toEntity(patchDto, noticeId);
         List<ImageInfoDto> infoList = imageMapper.toLocalDtoList(imageList, patchDto.getImageSortAndRepresentativeInfo(), UPLOAD_DIR);
 
         Notice responseNotice = service.patchNotice(infoList, patchDto.getDeleteImageId(), notice, patchDto.getUserId());
@@ -62,7 +62,7 @@ public class NoticeController {
         URI uri = UriCreator.createUri(UPLOAD_DIR, responseNotice.getId());
         var responseDto = ResponseDto.<NoticeIdResponseDto>builder().data(response).customCode(ResponseCode.OK).build();
 
-        return ResponseEntity.ok().header("Location",uri.toString()).body(responseDto);
+        return ResponseEntity.ok().header("Location", uri.toString()).body(responseDto);
     }
 
     @DeleteMapping("/{noticeId}")
@@ -72,4 +72,25 @@ public class NoticeController {
         return ResponseEntity.ok().body(responseDto);
     }
 
+    @GetMapping("")
+    public ResponseEntity getNoticeAll(Pageable pageable) {
+        Page<Notice> responseEntity = getService.getSimpleNotice(pageable);
+        Page<NoticeGetSimpleResponseDto> responsePage = noticeMapper.toGetSimplePageResponse(responseEntity);
+        var responseDto = ResponseDto.<Page<NoticeGetSimpleResponseDto>>builder()
+                .data(responsePage)
+                .customCode(ResponseCode.OK)
+                .build();
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/{noticeId}")
+    public ResponseEntity getNotice(@PathVariable Long noticeId) {
+        Notice responseEntity = getService.getNotice(noticeId);
+        NoticeGetResponseDto response = noticeMapper.toGetRseponseGetDto(responseEntity);
+        var responseDto = ResponseDto.<NoticeGetResponseDto>builder()
+                .data(response)
+                .customCode(ResponseCode.OK)
+                .build();
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/notice/dto/NoticeGetResponseDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/notice/dto/NoticeGetResponseDto.java
@@ -1,0 +1,23 @@
+package project.main.webstore.domain.notice.dto;
+
+import lombok.Getter;
+import project.main.webstore.domain.image.dto.ImageDto;
+import project.main.webstore.domain.notice.entity.Notice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class NoticeGetResponseDto {
+    List<ImageDto> imageList;
+    private Long noticeId;
+    private String title;
+    private String content;
+
+    public NoticeGetResponseDto(Notice notice) {
+        this.noticeId = notice.getId();
+        this.title = notice.getTitle();
+        this.content = notice.getContent();
+        this.imageList = notice.getNoticeImageList() != null ? notice.getNoticeImageList().stream().map(ImageDto::new).collect(Collectors.toList()) : null;
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/notice/dto/NoticeGetSimpleResponseDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/notice/dto/NoticeGetSimpleResponseDto.java
@@ -1,0 +1,17 @@
+package project.main.webstore.domain.notice.dto;
+
+import lombok.Getter;
+import project.main.webstore.domain.notice.entity.Notice;
+
+@Getter
+public class NoticeGetSimpleResponseDto {
+    private Long noticeId;
+    private String title;
+    private String content;
+
+    public NoticeGetSimpleResponseDto(Notice notice) {
+        this.noticeId = notice.getId();
+        this.title = notice.getTitle();
+        this.content = notice.getContent();
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/notice/dto/NoticeIdResponseDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/notice/dto/NoticeIdResponseDto.java
@@ -1,0 +1,10 @@
+package project.main.webstore.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NoticeIdResponseDto {
+    private Long noticeId;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/notice/dto/NoticePatchRequestDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/notice/dto/NoticePatchRequestDto.java
@@ -1,0 +1,19 @@
+package project.main.webstore.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import project.main.webstore.domain.image.dto.ImageSortDto;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class NoticePatchRequestDto {
+    @NotNull
+    private Long userId;
+    private String title;
+    private String content;
+    private List<Long> deleteImageId;
+    private List<ImageSortDto> imageSortAndRepresentativeInfo;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/notice/dto/NoticePostRequestDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/notice/dto/NoticePostRequestDto.java
@@ -1,0 +1,18 @@
+package project.main.webstore.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import project.main.webstore.domain.image.dto.ImageSortDto;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class NoticePostRequestDto {
+    private Long userId;
+    private String title;
+    private String content;
+    private List<ImageSortDto> infoList;
+
+
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/notice/mapper/NoticeMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/notice/mapper/NoticeMapper.java
@@ -1,9 +1,8 @@
 package project.main.webstore.domain.notice.mapper;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
-import project.main.webstore.domain.notice.dto.NoticeIdResponseDto;
-import project.main.webstore.domain.notice.dto.NoticePatchRequestDto;
-import project.main.webstore.domain.notice.dto.NoticePostRequestDto;
+import project.main.webstore.domain.notice.dto.*;
 import project.main.webstore.domain.notice.entity.Notice;
 
 @Component
@@ -21,5 +20,13 @@ public class NoticeMapper {
 
     public NoticeIdResponseDto toResponseDto(Notice notice) {
         return new NoticeIdResponseDto(notice.getId());
+    }
+
+    public Page<NoticeGetSimpleResponseDto> toGetSimplePageResponse (Page<Notice> notice) {
+        return notice.map(NoticeGetSimpleResponseDto::new);
+    }
+
+    public NoticeGetResponseDto toGetRseponseGetDto(Notice notice) {
+        return new NoticeGetResponseDto(notice);
     }
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/notice/mapper/NoticeMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/notice/mapper/NoticeMapper.java
@@ -1,0 +1,25 @@
+package project.main.webstore.domain.notice.mapper;
+
+import org.springframework.stereotype.Component;
+import project.main.webstore.domain.notice.dto.NoticeIdResponseDto;
+import project.main.webstore.domain.notice.dto.NoticePatchRequestDto;
+import project.main.webstore.domain.notice.dto.NoticePostRequestDto;
+import project.main.webstore.domain.notice.entity.Notice;
+
+@Component
+public class NoticeMapper {
+    public Notice toEntity(NoticePostRequestDto dto) {
+        return new Notice(dto.getTitle(),dto.getContent());
+    }
+
+    public Notice toEntity(NoticePatchRequestDto dto) {
+        return new Notice(dto.getTitle(),dto.getContent());
+    }
+    public Notice toEntity(NoticePatchRequestDto dto, Long noticeId){
+        return new Notice(noticeId, dto.getTitle(),dto.getContent());
+    }
+
+    public NoticeIdResponseDto toResponseDto(Notice notice) {
+        return new NoticeIdResponseDto(notice.getId());
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/utils/UriCreator.java
+++ b/BE/backend/src/main/java/project/main/webstore/utils/UriCreator.java
@@ -8,7 +8,7 @@ public class UriCreator {
     public static URI createUri(String defaultUrl1,String defaultUrl2, long resourceId1,long reviewId2) {
         return UriComponentsBuilder
                 .newInstance()
-                .path(defaultUrl1 + "/{resource-id1}" + defaultUrl2 + "/{resource-id2}")
+                .path("api/" + defaultUrl1 + "/{resource-id1}" + defaultUrl2 + "/{resource-id2}")
                 .buildAndExpand(resourceId1,reviewId2)
                 .toUri();
     }
@@ -16,8 +16,16 @@ public class UriCreator {
     public static URI createUri(String defaultUrl) {
         return UriComponentsBuilder
                 .newInstance()
-                .path(defaultUrl)
+                .path("api/" + defaultUrl)
                 .build()
+                .toUri();
+    }
+
+    public static URI createUri(String defaultUrl, long resourceId) {
+        return UriComponentsBuilder
+                .newInstance()
+                .path("api/" + defaultUrl + "/resource-id")
+                .buildAndExpand(resourceId)
                 .toUri();
     }
 }


### PR DESCRIPTION
# 작업 내용
1. Mapper 구현
2. Dto 구현
3. Controller 구현

# 회고
1. 전체 공지 리스트를 보내는 dto와 상세 조회 시 dto가 서로 다르다.
      * 서로 같을 때
             * 장점  :  dto 클래스의 재활용 가능
             * 단점 : 전체 조회 시 불필요한 내용(본문, 이미지)가 모두 같이 전달 된다.
      * 서로 다를 떄
             * 장점 : 딱 필요로하는 정보만 전달 가능
             * 단점 : dto 클래스 하나 더 추가
전체 리스트를 보낼 때와 상세 조회 시 dto를 같은 것을 보낼지 아니면 다른 것을 보낼 지 고민을 많이했다.
공지사항이 10년을 쓰더라도 1000개가 넘어가지 않을 정도롤 많이 사용하지 않는 것이기 때문에 딱 필요로만 하는 정보를 보내기 보다는 모든 정보를 다 보내는 것이 필요로 하는 정보를 보내고 다시 요청이 왔을 때 상세 내용을 다시 보내는 것 보다 효율적이지 않을까? 라는 생각을 했다.

    * 근거 1 : 전체 내용을 보낼 때 DB 연결 1회 , 상세 내역을 보낼 때 DB 연결 1회 -> 총 2회의 연결이 필요함
    * 근거 2: 전체 리스트를 보낼 때 한번에 전부 보내더라도 많아야 1000개 정도의 데이터만 보내면 된다 
보통 DB에 연결하는데 걸리는 리소스 소모가 큰 편이라고 한다.
자세하게는 알지 못하지만 그런 내용을 보았을 때 전달할 내용이 많지 않다면 한번의 연결에서 모든 데이터를 다 전달하는 편이 더 좋은 방향이 아닐까하는 생각이 든다.

지금 구현된 내용은 일단 따로 만들어서 원하는 정보들만 전달할 수 있게 만들었다.