### PR TITLE
결제 검증 시스템 1차 와성

### DIFF
--- a/BE/backend/build.gradle
+++ b/BE/backend/build.gradle
@@ -22,12 +22,13 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
@@ -49,8 +50,12 @@ dependencies {
 	implementation 'com.github.downgoon:MarvinPlugins:1.5.5'
 	implementation 'org.springframework.boot:spring-boot-starter-test'
 
-	// https://mvnrepository.com/artifact/com.google.guava/guava
+
 	implementation 'com.google.guava:guava:31.1-jre'
+	//스웨거
+	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+	//아임포트
+	implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
 
 }
 

--- a/BE/backend/src/main/java/project/main/webstore/config/RedisConfig.java
+++ b/BE/backend/src/main/java/project/main/webstore/config/RedisConfig.java
@@ -1,0 +1,51 @@
+package project.main.webstore.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        //일반적인 key:value의 경우 시리얼라이저
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class)); // JSON 직렬화를 위해 Jackson2JsonRedisSerializer 사용
+
+        // Hash를 사용할 경우 시리얼라이저
+        //redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        //redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        //모든 경우
+        //redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+        redisTemplate.setEnableTransactionSupport(true);  // 설정 필요한 부분
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+        return new JpaTransactionManager();
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/config/javaConfig.java
+++ b/BE/backend/src/main/java/project/main/webstore/config/javaConfig.java
@@ -1,0 +1,20 @@
+package project.main.webstore.config;
+
+import com.siot.IamportRestClient.IamportClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class javaConfig {
+    @Value("${iamport.api-key}")
+    private String apiKey;
+    @Value("${iamport.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public IamportClient iamportClient(){
+        return new IamportClient(apiKey, secretKey);
+    }
+
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/coupon/entity/Coupon.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/coupon/entity/Coupon.java
@@ -2,8 +2,10 @@ package project.main.webstore.domain.coupon.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import project.main.webstore.audit.Auditable;
 import project.main.webstore.domain.coupon.enums.CouponStatus;
+import project.main.webstore.domain.order.entity.Orders;
 import project.main.webstore.domain.payment.entity.Payment;
 import project.main.webstore.valueObject.Duration;
 import project.main.webstore.valueObject.Price;
@@ -57,4 +59,8 @@ public class Coupon extends Auditable {
     //payment  쿠폰 결제 : 하나의 결제에 여러개의 쿠폰을 사용할 수 있다. ->   여러개의 쿠폰이 하나의 결제에 사용이 가능하다. ManyToOne
     @ManyToOne(fetch = LAZY)
     private Payment payment;
+
+    @Setter
+    @ManyToOne(fetch = LAZY)
+    private Orders order;
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/order/enums/OrdersStatus.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/order/enums/OrdersStatus.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum OrdersStatus {
     ORDER_COMPLETE("주문 완료"),
+    DEPOSIT_COMPLETE("입금 완료"),
+
     ORDER_CANCEL("주문 취소");
 
     public String ordersStauts;

--- a/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/entity/OrderHistory.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/orderHistory/entity/OrderHistory.java
@@ -6,9 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import project.main.webstore.audit.Auditable;
 import project.main.webstore.domain.cart.entity.Cart;
-import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.order.entity.OrderItem;
-import project.main.webstore.domain.order.entity.Orders;
 import project.main.webstore.domain.orderHistory.enums.OrderStatus;
 import project.main.webstore.domain.payment.entity.Payment;
 import project.main.webstore.domain.users.entity.User;
@@ -16,7 +14,6 @@ import project.main.webstore.valueObject.Address;
 import project.main.webstore.valueObject.Price;
 
 import javax.persistence.*;
-
 import java.util.List;
 
 import static javax.persistence.EnumType.STRING;
@@ -68,7 +65,7 @@ public class OrderHistory extends Auditable {
     public void setPayment(Payment payment) {
         this.payment = payment;
         if(payment.getOrderHistory() != this) {
-            payment.setOrderHistory(this);
+//            payment.setOrderHistory(this);
         }
     }
 

--- a/BE/backend/src/main/java/project/main/webstore/domain/payment/controller/PaymentController.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/payment/controller/PaymentController.java
@@ -41,5 +41,14 @@ public class PaymentController {
         return ResponseEntity.ok(responseDto);
     }
 
+    @GetMapping("/post-vlaid/{orderNumber}")
+    public ResponseEntity validPayment(@ModelAttribute PrepareData prepareData,
+                                       @RequestParam String iamId,
+                                       @RequestParam String orderNumber,
+                                       @RequestParam long userId){
+        String s = paymentService.validatePayment(prepareData, iamId, orderNumber, userId);
+        var responseDto = ResponseDto.builder().data(s).build();
+        return ResponseEntity.ok(responseDto);
+    }
     //결제 취소 조회는 order 완성되고 난 이후 작업 진행 예정
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/payment/controller/PaymentController.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/payment/controller/PaymentController.java
@@ -44,8 +44,8 @@ public class PaymentController {
     @GetMapping("/post-vlaid/{orderNumber}")
     public ResponseEntity validPayment(@ModelAttribute PrepareData prepareData,
                                        @RequestParam String iamId,
-                                       @RequestParam String orderNumber,
-                                       @RequestParam long userId){
+                                       @PathVariable String orderNumber,
+                                       @RequestParam long userId){  //로그인 성공 시 로직 변경 필요
         String s = paymentService.validatePayment(prepareData, iamId, orderNumber, userId);
         var responseDto = ResponseDto.builder().data(s).build();
         return ResponseEntity.ok(responseDto);

--- a/BE/backend/src/main/java/project/main/webstore/domain/payment/controller/PaymentController.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/payment/controller/PaymentController.java
@@ -1,0 +1,45 @@
+package project.main.webstore.domain.payment.controller;
+
+import com.siot.IamportRestClient.request.PrepareData;
+import com.siot.IamportRestClient.response.IamportResponse;
+import com.siot.IamportRestClient.response.Prepare;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import project.main.webstore.domain.payment.service.PaymentService;
+import project.main.webstore.dto.ResponseDto;
+import project.main.webstore.enums.ResponseCode;
+import project.main.webstore.utils.UriCreator;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("api/payment")
+@RequiredArgsConstructor
+public class PaymentController {
+    private final PaymentService paymentService;
+
+//    백엔드 단에서 결제 시스템 띄울떄 사용
+//    @GetMapping("/api/pay")
+//    public String payProduct() {
+//
+//        return "pay-Iamport";
+//    }
+
+    @PostMapping("/prepare")
+    public ResponseEntity postPrepare(@RequestBody PrepareData prepareData) {
+        PrepareData resultPrepare = paymentService.postPrepare(prepareData);
+        var responseDto = ResponseDto.<PrepareData>builder().data(resultPrepare).customCode(ResponseCode.CREATED);
+        URI location = UriCreator.createUri("api/payment/pre-valid/{orderNumber}", resultPrepare.getMerchant_uid());
+        return ResponseEntity.created(location).body(responseDto);
+    }
+
+    @GetMapping("/pre-valid/{orderNumber}")
+    public ResponseEntity getPrepare(@PathVariable String orderNumber, @RequestParam int price){
+        IamportResponse<Prepare> prepare = paymentService.getPrepare(orderNumber, price);
+        var responseDto = ResponseDto.<IamportResponse<Prepare>>builder().data(prepare).customCode(ResponseCode.OK).build();
+        return ResponseEntity.ok(responseDto);
+    }
+
+    //결제 취소 조회는 order 완성되고 난 이후 작업 진행 예정
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/payment/entity/Payment.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/payment/entity/Payment.java
@@ -2,8 +2,10 @@ package project.main.webstore.domain.payment.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import project.main.webstore.audit.Auditable;
 import project.main.webstore.domain.coupon.entity.Coupon;
+import project.main.webstore.domain.order.entity.Orders;
 import project.main.webstore.domain.orderHistory.entity.OrderHistory;
 import project.main.webstore.domain.payment.enums.PaymentStatus;
 import project.main.webstore.domain.users.entity.User;
@@ -36,4 +38,8 @@ public class Payment extends Auditable {
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "ORDERHISTORY_ID")
     private OrderHistory orderHistory;
+
+    @Setter
+    @OneToOne(fetch = LAZY)
+    private Orders order;
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/payment/exception/PaymentExceptionCode.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/payment/exception/PaymentExceptionCode.java
@@ -1,0 +1,22 @@
+package project.main.webstore.domain.payment.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import project.main.webstore.exception.ExceptionCode;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentExceptionCode implements ExceptionCode {
+    PAYMENT_AUTHENTIC_NOT_FOUND(HttpStatus.UNAUTHORIZED,"토큰 도입 시 권한 인증을 실패했습니다."),
+    PAYMENT_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"결제 서버 문제 발생" ),
+    PAYMENT_SERVER_CONNECTING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "결제 서버 연결 문제 발생"),
+    FABRICATED_PAYMENT(HttpStatus.CONFLICT,"결제 정보 불일치"),
+    PREPARE_GET_ERROR(HttpStatus.CONFLICT,"사전 금액 조회 실패"),
+    PAYMENT_SERVER_AUTHINC_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"결제 서버 권한 문제 발생"),
+    PAYMENT_AMOUNT_CONFLICT(HttpStatus.CONFLICT,"가격 불일치"),
+    PAYMENT_ACCESS_TIME_ERROR(HttpStatus.CONFLICT,"결제 요청 시간 초과"),
+    ;
+    private HttpStatus httpStatus;
+    private String message;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/payment/service/PaymentService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/payment/service/PaymentService.java
@@ -1,0 +1,158 @@
+package project.main.webstore.domain.payment.service;
+
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+import com.siot.IamportRestClient.request.PrepareData;
+import com.siot.IamportRestClient.response.IamportResponse;
+import com.siot.IamportRestClient.response.Prepare;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.main.webstore.domain.order.entity.Orders;
+import project.main.webstore.domain.payment.exception.PaymentExceptionCode;
+import project.main.webstore.exception.BusinessLogicException;
+import project.main.webstore.redis.RedisUtils;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PaymentService {
+
+    //    private final OrderService orderService;
+    private final IamportClient client;
+    private final RedisUtils redisUtils;
+    private final int SAVE_PAY_ACCESS_TIME = 10;
+    //AOP 이용 가능성 확인   사전 등록 -> 사전 등록 시 레디스에 캐시 메모리로 저장, 이후 진짜 저장할 떄 DB에 저장 하면 좋지 않나? 하는 조그만한 생각을 가지고 있음
+
+    private static void validPriceEquals(int iamPrice, int checkPrice) {
+        if (checkPrice != iamPrice) {
+            throw new BusinessLogicException(PaymentExceptionCode.PAYMENT_AMOUNT_CONFLICT);
+        }
+    }
+
+    private static void validPaymentAccessTime(PrepareData findByKey) {
+        if(findByKey == null){
+            throw new BusinessLogicException(PaymentExceptionCode.PAYMENT_ACCESS_TIME_ERROR);
+        }
+    }
+
+    //프론트엔드와의 상의를 통해 데이터를 변경할 필요가 있을 수 있음
+    public PrepareData postPrepare(String orderNumber, int amount, Orders order) {
+        PrepareData prepareData = null;
+        try {
+            prepareData = new PrepareData(orderNumber, new BigDecimal(amount));
+            IamportResponse<Prepare> iamportResponse = client.postPrepare(prepareData);
+        } catch (IamportResponseException e) {
+            if (e.getHttpStatusCode() == 401) { //검증 실패 ( 토큰 문제)
+                log.error("### 결제 서버 권한 문제 발생 {}", e.getMessage());
+                log.trace("결제 서버 권한 문제 발생 ", e);
+                throw new BusinessLogicException(PaymentExceptionCode.PAYMENT_AUTHENTIC_NOT_FOUND);
+            } else {    //500 에러 발생
+                log.error("### 결제 서버 에러 발생 {}", e.getMessage());
+                log.trace("결제 서버 에러 발생 ", e);
+                throw new BusinessLogicException(PaymentExceptionCode.PAYMENT_SERVER_ERROR);
+            }
+        } catch (IOException e) {
+            log.error("### 연결 시 에러 발생");
+            log.trace("### 에러 발생", e);
+            throw new BusinessLogicException(PaymentExceptionCode.PREPARE_GET_ERROR);
+        } catch (AssertionError e) {
+            log.error("### 가격 정보 불일치");
+            throw new BusinessLogicException(PaymentExceptionCode.PAYMENT_AMOUNT_CONFLICT);
+        }
+        redisUtils.set(prepareData.getMerchant_uid(),prepareData,SAVE_PAY_ACCESS_TIME);
+        return prepareData;
+    }
+
+    //사전 저장 데이터와의 일치 여부 체크용
+    public String validatePayment(PrepareData prepareData, String impUid, String orderNumber, long userId)
+    {
+        PrepareData findByKey = (PrepareData) redisUtils.findByKey(prepareData.getMerchant_uid());
+        int redisPrice = findByKey.getAmount().intValue();
+
+        validPaymentAccessTime(findByKey);
+
+        int postPrice = prepareData.getAmount().intValue();
+        int impPrice = 0;
+
+        try {
+            impPrice = client.paymentByImpUid(impUid).getResponse().getAmount().intValue();
+        } catch (IamportResponseException e) {
+            if (e.getHttpStatusCode() == 401) { //검증 실패 ( 토큰 문제)
+                log.error("### 결제 서버 권한 문제 발생 {}", e.getMessage());
+                log.trace("결제 서버 권한 문제 발생 ", e);
+                throw new BusinessLogicException(PaymentExceptionCode.PAYMENT_AUTHENTIC_NOT_FOUND);
+            } else {    //500 에러 발생
+                log.error("### 결제 서버 에러 발생 {}", e.getMessage());
+                log.trace("결제 서버 에러 발생 ", e);
+                throw new BusinessLogicException(PaymentExceptionCode.PAYMENT_SERVER_ERROR);
+            }
+        } catch (IOException e){
+            log.error("### 연결 시 에러 발생");
+            log.trace("### 에러 발생", e);
+            throw new BusinessLogicException(PaymentExceptionCode.PREPARE_GET_ERROR);
+        }
+        validPriceEquals(postPrice,impPrice,redisPrice);
+
+        // 일치하면 주문완료로 상태 변경
+
+        // 결제정보 저장
+
+        // 장바구니에 담겨있던 물건 삭제
+
+        return "결제 성공";
+    }
+
+    //결제 사후 검증
+    private IamportResponse<Prepare> getPrepare(String orderNumber, int price) {
+        IamportResponse<Prepare> prepare = null;
+        PrepareData findByKey = (PrepareData) redisUtils.findByKey(orderNumber);
+
+        validPaymentAccessTime(findByKey);
+
+        try {
+            prepare = client.getPrepare(orderNumber);
+            assertEquals(prepare.getCode(), 0);  //0 일치 검증
+        } catch (IamportResponseException e) {
+            if (e.getHttpStatusCode() == 401) { //검증 실패 ( 토큰 문제)
+                log.error("### 결제 서버 권한 문제 발생 {}", e.getMessage());
+                log.trace("결제 서버 권한 문제 발생 ", e);
+                throw new BusinessLogicException(PaymentExceptionCode.PAYMENT_AUTHENTIC_NOT_FOUND);
+            } else {    //500 에러 발생
+                log.error("### 결제 서버 에러 발생 {}", e.getMessage());
+                log.trace("결제 서버 에러 발생 ", e);
+                throw new BusinessLogicException(PaymentExceptionCode.PAYMENT_SERVER_ERROR);
+            }
+        } catch (IOException e) {
+            log.error("### 연결 시 에러 발생");
+            log.trace("### 에러 발생", e);
+            throw new BusinessLogicException(PaymentExceptionCode.PREPARE_GET_ERROR);
+
+        } catch (AssertionError e) {
+            log.error("### 아임포트 연결 에러 발생  = {}", prepare.getMessage());
+            log.trace("### 에러 발생", e);
+            throw new BusinessLogicException(PaymentExceptionCode.PREPARE_GET_ERROR);
+        }
+
+        validPriceEquals(price, findByKey.getAmount().intValue());
+
+        return prepare;
+    }
+
+    private void validPriceEquals(int requestPrice, int iamPrice, int redisPrice) {
+        if (requestPrice != iamPrice || requestPrice != redisPrice) {
+
+            //환불 로직이 들어가야한다.
+
+
+            throw new BusinessLogicException(PaymentExceptionCode.FABRICATED_PAYMENT);
+        }
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/redis/RedisUtils.java
+++ b/BE/backend/src/main/java/project/main/webstore/redis/RedisUtils.java
@@ -1,0 +1,31 @@
+package project.main.webstore.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtils {
+    private final RedisTemplate<String, Object> redisTemplate;
+    public void set(String key, Object o, int minutes) {
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(o.getClass()));
+        redisTemplate.opsForValue().set(key, o, minutes, TimeUnit.MINUTES);
+    }
+
+    public Object findByKey(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+    public Object patch(String key, Object newData) {
+        Object newSavedData = redisTemplate.opsForValue().getAndSet(key, newData);
+        return newSavedData;
+
+    }
+    public boolean delete(String key) {
+        return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+
+}

--- a/BE/backend/src/main/java/project/main/webstore/utils/UriCreator.java
+++ b/BE/backend/src/main/java/project/main/webstore/utils/UriCreator.java
@@ -28,4 +28,11 @@ public class UriCreator {
                 .buildAndExpand(resourceId)
                 .toUri();
     }
+    public static URI createUri(String defaultUrl, String resourceId) {
+        return UriComponentsBuilder
+                .newInstance()
+                .path("api/" + defaultUrl + "/resource-id")
+                .buildAndExpand(resourceId)
+                .toUri();
+    }
 }

--- a/BE/backend/src/main/resources/application.yml
+++ b/BE/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL55Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         highlight_sql: true
@@ -15,11 +15,14 @@ spring:
         format_sql: true
         default_batch_fetch_size: 100
     database: mysql
-    open-in-view: false
+#    open-in-view: false
   servlet:
     multipart:
       max-file-size: 10MB
       max-request-size: 20MB
+  redis:
+    host: localhost
+    port: 6379
 logging:
   level:
     org.hibernate.sql: info
@@ -35,3 +38,16 @@ cloud:
     credentials:
       accessKey: ${S3_ACCESS_KEY}
       secretKey: ${S3_SECRET_KEY}
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    tags-sorter: alpha
+    disable-swagger-default-url: true
+    path: /swagger-ui
+  paths-to-match: /api/**
+
+iamport:
+  api-key: 1558762544126242
+  secret-key: rHqopNfJBD7yr39miijLfcRG6VXeIxGgXgrXIjGqsgoK5tGpRHJ8mfm9z3IIvYdHeSzUf0AkGzMxO1ab

--- a/BE/backend/src/main/resources/templates/pay-Iamport.html
+++ b/BE/backend/src/main/resources/templates/pay-Iamport.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- jQuery -->
+    <script
+            src="https://code.jquery.com/jquery-1.12.4.min.js"
+            type="text/javascript"
+    ></script>
+    <!-- iamport.payment.js -->
+    <script
+            src="https://cdn.iamport.kr/js/iamport.payment-1.2.0.js"
+            type="text/javascript"
+    ></script>
+    <script>
+        const IMP = window.IMP;
+        IMP.init("imp82370458");
+
+        function requestPay() {
+            IMP.request_pay(
+                {
+                    pg: "html5_inicis",
+                    pay_method: "card",
+                    merchant_uid: "57008833-33004",
+                    name: "당근 10kg",
+                    amount: 1004,
+                    buyer_email: "Iamport@chai.finance",
+                    buyer_name: "포트원 기술지원팀",
+                    buyer_tel: "010-1234-5678",
+                    buyer_addr: "서울특별시 강남구 삼성동",
+                    buyer_postcode: "123-456",
+                },
+                function (rsp) {
+                    // callback
+                    //rsp.imp_uid 값으로 결제 단건조회 API를 호출하여 결제결과를 판단합니다.
+                }
+            );
+        }
+        requestPay()
+    </script>
+    <meta charset="UTF-8" />
+    <title>Sample Payment</title>
+</head>
+<body>
+<!--<button onclick="requestPay()">결제하기</button>-->
+<!-- 결제하기 버튼 생성 -->
+
+</body>
+</html>


### PR DESCRIPTION
# 작업 내용
1. 결제 내역 사전 저장 기능 
2. 결제 내역 사전 검증 (결제 내역 조회 시)
3. 결제 내역 사 후 검증 로직 구현

# 작업 회고
1. iamport api를 이용해 구현 -> 원리를 이해하면 빠르게 구현이 가능해진다.
2. 결제 관련 로직이다 보니 사전 검증 및 사후 검증이 중요하다는 것을 느꼈다. 
3. 블로그를 보면 대부분 사전 검증 보다는 사후 검증에 백엔드가 중점을 두고 있는데 뭔가 사전에 검증하는 것도 백엔드에서 처리하면 좋지 않을까 하는 생각에 사전 검증진행 
4. 검증 로직
사전 저장된 내용을 redis에 저장(DB 저장이 아닌 이유는 삭제가 빈번하고 특정 시간만 필요로함) -> 시간 만료 or 요청에서 보내는 데이터와 redis 저장된 데이터 일치 여부 체크  일치 한다면 사전 검증이 성공
사 후 검증 : redis 조회를 통한 시간 만료 체크, redis 데이터와 요청 시 받은 데이터, iamport에서 조회한 데이터가 모두 일치하는지 여부 체크 후 모든 것이 일치할 경우 승인을 진행한다.