### PR TITLE
UserController 구현 1차 완료

### DIFF
--- a/BE/backend/src/main/java/project/main/webstore/domain/users/controller/UserController.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/users/controller/UserController.java
@@ -1,21 +1,103 @@
 package project.main.webstore.domain.users.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import project.main.webstore.domain.image.dto.ImageInfoDto;
+import project.main.webstore.domain.image.mapper.ImageMapper;
+import project.main.webstore.domain.users.dto.UserGetResponseDto;
+import project.main.webstore.domain.users.dto.UserIdResponseDto;
+import project.main.webstore.domain.users.dto.UserPatchRequestDto;
 import project.main.webstore.domain.users.dto.UserPostRequestDto;
 import project.main.webstore.domain.users.entity.User;
+import project.main.webstore.domain.users.mapper.UserMapper;
 import project.main.webstore.domain.users.service.UserService;
+import project.main.webstore.dto.ResponseDto;
+import project.main.webstore.enums.ResponseCode;
+import project.main.webstore.utils.CheckLoginUser;
+import project.main.webstore.utils.UriCreator;
+
+import java.net.URI;
 
 @RestController
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
+    private final String UPLOAD_DIR = "user";
     private final UserService service;
-    @PostMapping("/users")
-    public void postUser(@RequestBody UserPostRequestDto post) {
-        User user = new User(post);
-        service.postUser(user,null);
+    private final UserMapper userMapper;
+    private final ImageMapper imageMapper;
+    @PostMapping
+    public ResponseEntity postUser(@RequestPart UserPostRequestDto post,
+                                   @RequestPart(required = false) MultipartFile image) {
+        User user = userMapper.toEntity(post);
+        ImageInfoDto infoDto =null;
+        if (image != null) {
+            infoDto = imageMapper.toLocalDto(image, post.getImageInfo(), UPLOAD_DIR);
+        }
+        User result = service.postUser(user, infoDto);
+        UserIdResponseDto response = userMapper.toDto(result);
+        var responseDto = ResponseDto.builder().data(response).customCode(ResponseCode.CREATED);
+        URI location = UriCreator.createUri("/api/users/{userId}", response.getUserId());
 
+        return ResponseEntity.created(location).body(responseDto);
     }
+
+    //어드민은 절대자의 권한이 존재한다. -|> 절대자의 권한을 사용하자.
+    @PatchMapping("/{userId}")
+    public ResponseEntity patchUser(@PathVariable Long userId,
+                                    @RequestPart UserPatchRequestDto patch,
+                                    @RequestPart(required = false) MultipartFile image,
+                                    @AuthenticationPrincipal Object principal){
+        CheckLoginUser.validUserSame(principal,userId);
+        User request = userMapper.toEntity(patch);
+        request.setId(userId);
+        ImageInfoDto infoDto = null;
+        if(image != null){
+            infoDto = imageMapper.toLocalDto(image, patch.getImageInfo(), UPLOAD_DIR);
+        }
+        User result = service.patchUser(request, infoDto);
+
+        UserIdResponseDto response = userMapper.toDto(result);
+        var responseDto = ResponseDto.builder().data(response).customCode(ResponseCode.CREATED);
+        URI location = UriCreator.createUri("/api/users/{userId}", response.getUserId());
+
+        return ResponseEntity.ok().header("Location",location.toString()).body(responseDto);
+    }
+
+    //관리자 or 당사자만 볼 수 있음
+    @GetMapping("/{userId}")
+    public ResponseEntity getUser(@PathVariable Long userId,
+                                  @AuthenticationPrincipal Object principal){
+        CheckLoginUser.validUserSame(principal,userId);
+        User result = service.getUser(userId);
+        UserGetResponseDto response = userMapper.toGetDtoResponse(result);
+        var responseDto = ResponseDto.builder().data(response).customCode(ResponseCode.OK).build();
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping
+    public ResponseEntity getUserPage(@AuthenticationPrincipal Object principal,
+                                      Pageable pageable){
+        CheckLoginUser.validAdmin(principal);
+        Page<User> result = service.getUserPage(pageable);
+        Page<UserGetResponseDto> response = userMapper.toGetDtoResponse(result);
+        var responseDto = ResponseDto.builder().data(response).customCode(ResponseCode.OK).build();
+
+        return ResponseEntity.ok(responseDto);
+    }
+    @DeleteMapping("/{userId}")
+    public ResponseEntity deleteUser(@PathVariable Long userId,
+                                     @AuthenticationPrincipal Object principal){
+        CheckLoginUser.validUserSame(principal,userId);
+        service.deleteUser(userId);
+
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/users/dto/UserGetResponseDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/users/dto/UserGetResponseDto.java
@@ -1,0 +1,26 @@
+package project.main.webstore.domain.users.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import project.main.webstore.domain.users.entity.User;
+import project.main.webstore.valueObject.Address;
+
+@Getter
+@AllArgsConstructor
+public class UserGetResponseDto {
+    private Long userId;
+    private String email;
+    private String password;
+    private String nickname;
+    private String profileImage;
+    private Address address;
+
+    public UserGetResponseDto(User user) {
+        this.userId = user.getId();
+        this.email = user.getEmail();
+        this.password = user.getPassword();
+        this.nickname = user.getNickName();
+        this.profileImage = user.getProfileImage();
+        this.address = user.getAddress();
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/users/dto/UserIdResponseDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/users/dto/UserIdResponseDto.java
@@ -1,0 +1,10 @@
+package project.main.webstore.domain.users.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserIdResponseDto {
+    private Long userId;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/users/dto/UserPatchRequestDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/users/dto/UserPatchRequestDto.java
@@ -4,16 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import project.main.webstore.domain.image.dto.ImageSortDto;
 
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
 @Getter
 @AllArgsConstructor
-public class UserPostRequestDto {
-    @NotBlank
-    @Email
-    private String email;
+public class UserPatchRequestDto {
+
     //패스워드 검증용 필드 필요
     @NotBlank
     private String password;

--- a/BE/backend/src/main/java/project/main/webstore/domain/users/entity/User.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/users/entity/User.java
@@ -1,9 +1,11 @@
 package project.main.webstore.domain.users.entity;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.users.dto.UserPatchRequestDto;
 import project.main.webstore.domain.users.dto.UserPostRequestDto;
 import project.main.webstore.domain.users.enums.Grade;
 import project.main.webstore.domain.users.enums.ProviderId;
@@ -12,7 +14,6 @@ import project.main.webstore.domain.users.enums.UserStatus;
 import project.main.webstore.valueObject.Address;
 
 import javax.persistence.*;
-import javax.security.auth.Subject;
 import java.security.Principal;
 import java.time.LocalDateTime;
 
@@ -80,9 +81,27 @@ public class User extends Auditable implements Principal {
         this.userStatus = userStatus;
     }
 
+    @Builder(builderMethodName = "jwtBuilder")
     public User(UserPostRequestDto post) {
-        this.nickName = post.getName();
+        this.nickName = post.getNickname();
         this.password = post.getPassword();
         this.email = post.getEmail();
+        this.lastConnectedDate = LocalDateTime.now();
+        this.address = new Address(post.getZipCode(),post.getAddressSimple(),post.getAddressDetail(), post.getPhone());
+        this.grade = Grade.NORMAL;
+        this.providerId = ProviderId.JWT;
+        this.userRole = UserRole.CLIENT;
+        this.userStatus = UserStatus.TMP;
+    }
+    @Builder(builderMethodName = "patchBuilder")
+    public User(UserPatchRequestDto patch) {
+        this.nickName = patch.getNickname();
+        this.password = patch.getPassword();
+        this.lastConnectedDate = LocalDateTime.now();
+        this.address = new Address(patch.getZipCode(),patch.getAddressSimple(),patch.getAddressDetail(), patch.getPhone());
+        this.grade = Grade.NORMAL;
+        this.providerId = ProviderId.JWT;
+        this.userRole = UserRole.CLIENT;
+        this.userStatus = UserStatus.TMP;
     }
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/users/exception/UserExceptionCode.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/users/exception/UserExceptionCode.java
@@ -12,7 +12,10 @@ public enum UserExceptionCode implements ExceptionCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"회원을 찾을 수 없습니다."),
     USER_JWT_EXIST(HttpStatus.CONFLICT,"JWT 회원이 이미 존재 합니다."),
     USER_NOT_JWT(HttpStatus.CONFLICT, "소셜 로그인 회원입니다."),
-    USER_NOT_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없습니다.");
+    USER_NOT_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+    USER_INFO_MISMATCH(HttpStatus.CONFLICT, "회원 정보가 일치하지 않습니다."),
+    USER_NOT_LOGIN(HttpStatus.UNAUTHORIZED, "회원이 접근할 수 없습니다."),
+    NOT_ADMIN(HttpStatus.UNAUTHORIZED, "관리자가 아닙니다.");
     private final HttpStatus httpStatus;
 
     private final String message;

--- a/BE/backend/src/main/java/project/main/webstore/domain/users/mapper/UserMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/users/mapper/UserMapper.java
@@ -1,0 +1,30 @@
+package project.main.webstore.domain.users.mapper;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+import project.main.webstore.domain.users.dto.UserGetResponseDto;
+import project.main.webstore.domain.users.dto.UserIdResponseDto;
+import project.main.webstore.domain.users.dto.UserPatchRequestDto;
+import project.main.webstore.domain.users.dto.UserPostRequestDto;
+import project.main.webstore.domain.users.entity.User;
+
+@Component
+public class UserMapper {
+    public User toEntity(UserPostRequestDto post) {
+        return User.jwtBuilder().post(post).build();
+    }
+
+    public User toEntity(UserPatchRequestDto patch) {
+        return User.patchBuilder().patch(patch).build();
+    }
+    public UserIdResponseDto toDto(User user) {
+        return new UserIdResponseDto(user.getId());
+    }
+    public UserGetResponseDto toGetDtoResponse(User user){
+        return new UserGetResponseDto(user);
+    }
+
+    public Page<UserGetResponseDto> toGetDtoResponse(Page<User> userPage) {
+        return userPage.map(UserGetResponseDto::new);
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/users/service/UserService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/users/service/UserService.java
@@ -11,7 +11,6 @@ import project.main.webstore.domain.image.dto.ImageInfoDto;
 import project.main.webstore.domain.image.entity.Image;
 import project.main.webstore.domain.users.entity.User;
 import project.main.webstore.domain.users.enums.ProviderId;
-import project.main.webstore.domain.users.enums.UserRole;
 import project.main.webstore.domain.users.enums.UserStatus;
 import project.main.webstore.domain.users.exception.UserExceptionCode;
 import project.main.webstore.domain.users.repository.UserRepository;
@@ -72,11 +71,7 @@ public class UserService {
         return validUserExist(userId);
     }
 
-    public Page<User> getUserPage(Long userId, Pageable pageable) {
-        User user = validUserExist(userId);
-        if (user.getUserRole() != UserRole.ADMIN) {
-            throw new BusinessLogicException(UserExceptionCode.USER_NOT_ACCESS);
-        }
+    public Page<User> getUserPage(Pageable pageable) {
         Page<User> userPage = userRepository.findUserPage(pageable);
         return userPage;
     }
@@ -116,7 +111,7 @@ public class UserService {
      * 회원이 없으명 예외 발생
      * */
     // 내부 동작 메서드 //
-    public User validUserExist(Long UserId) {
+    private User validUserExist(Long UserId) {
         return userRepository.findById(UserId).orElseThrow(() -> new BusinessLogicException(UserExceptionCode.USER_NOT_FOUND));
     }
 

--- a/BE/backend/src/main/java/project/main/webstore/security/jwt/filter/JwtVerificationFilter.java
+++ b/BE/backend/src/main/java/project/main/webstore/security/jwt/filter/JwtVerificationFilter.java
@@ -31,7 +31,7 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
         LinkedHashMap userInfoMap = (LinkedHashMap) claims.get("userInfo");
 
         //리펙토링 대상
-        Long id =  Long.valueOf((String)userInfoMap.get("userId"));
+        Long id =  Long.valueOf((String)userInfoMap.get("userIdStr"));
         String email = (String) userInfoMap.get("email");
         String nickName = (String) userInfoMap.get("nickName");
         UserRole userRole = UserRole.transEnum((String) userInfoMap.get("userRole"));

--- a/BE/backend/src/main/java/project/main/webstore/utils/CheckLoginUser.java
+++ b/BE/backend/src/main/java/project/main/webstore/utils/CheckLoginUser.java
@@ -1,0 +1,53 @@
+package project.main.webstore.utils;
+
+
+import project.main.webstore.domain.users.enums.UserRole;
+import project.main.webstore.domain.users.exception.UserExceptionCode;
+import project.main.webstore.exception.BusinessLogicException;
+import project.main.webstore.security.dto.UserInfoDto;
+
+public class CheckLoginUser {
+
+    public static String getUserNickname(Object principal) {
+        if (principal instanceof String) {
+             return principal.toString();
+        } else {
+            return ((UserInfoDto) principal).getNickName();
+        }
+    }
+    public static UserInfoDto getUserInfoByContext(Object principal) {
+        if (principal instanceof String) {
+             return null;
+        } else {
+            return ((UserInfoDto) principal);
+        }
+    }
+    public static void validUserSame(Object principal, Long userId){
+        if(principal instanceof String){
+            throw new BusinessLogicException(UserExceptionCode.USER_NOT_LOGIN);
+        }
+        UserInfoDto info = (UserInfoDto) principal;
+        if(info.getUserId() != userId){
+            throw new BusinessLogicException(UserExceptionCode.USER_INFO_MISMATCH);
+        }
+    }
+    public static void validAdmin(Object principal){
+        if(principal instanceof String){
+            throw new BusinessLogicException(UserExceptionCode.USER_NOT_LOGIN);
+        }
+        UserInfoDto info = (UserInfoDto) principal;
+        if(!info.getUserRole().equals(UserRole.ADMIN)){
+            throw new BusinessLogicException(UserExceptionCode.NOT_ADMIN);
+        }
+    }
+
+
+    public static Long getContextIdx(Object principal) {
+        if (principal instanceof String) {
+            return -1L;
+        } else {
+            return ((UserInfoDto) principal).getUserId();
+        }
+    }
+
+}


### PR DESCRIPTION
# 작업내용
1. 컨트롤러 CRUD 구현
2. 시큐리티 컨텍스트에서 사용자 정보 가져오거나 검증하는 메서드 추가

# 작업 회고
* 시큐리티 컨텍스트에서 사용자 정보를 받는다고 해도 UserId를 한번 더 검증해야 데이터의 위 변조에 대응 할 수 있을 것이라고 판단
* 작업하면서 refreshToken 탈취 시 문제가 발생할 수 있다는 것을 인지, 동일 IP에서 요청하는 것이 아니면 금지하는 로직 추가가 필요할 것 같다.(API 구현 완료 후 작업 진행 예정)

# 특이사항
* 비밀번호 찾기 기능 미구현 ( 메일 인증 및 메일 인증 후 임시 비밀번호 제공 or 바로 비밀번호 알려주는 로직 중 선택 필요)
* 비밀번호 찾기 기능을 구현하기 위해서는 일단 임시 회원으로 등록한 후 추가적인 로직을 등록할 필요가 있다. 
