### PR TITLE
장바구니 기능 구현

### DIFF
--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/controller/CartController.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/controller/CartController.java
@@ -1,0 +1,64 @@
+package project.main.webstore.domain.cart.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import project.main.webstore.domain.cart.dto.*;
+import project.main.webstore.domain.cart.entity.Cart;
+import project.main.webstore.domain.cart.mapper.CartMapper;
+import project.main.webstore.domain.cart.service.CartService;
+import project.main.webstore.dto.ResponseDto;
+import project.main.webstore.enums.ResponseCode;
+import project.main.webstore.utils.UriCreator;
+
+import java.net.URI;
+import java.util.List;
+
+@RequestMapping("/api/cart")
+@RestController
+@RequiredArgsConstructor
+public class CartController {
+    private final CartService cartService;
+    private final CartMapper mapper;
+    @PostMapping("/users/{userId}")
+    public ResponseEntity<ResponseDto<CartIdResponseDto>> postCart(@RequestBody CartPostRequestDto post, @PathVariable Long userId){
+        List<LocalCartDto> request = mapper.toLocalList(post.getItemList());
+        Cart result = cartService.postCart(request, userId);
+
+        CartIdResponseDto response = mapper.toResponseId(result);
+        URI location = UriCreator.createUri("/cart/userId", response.getUserId());
+        ResponseDto<CartIdResponseDto> responseDto = ResponseDto.<CartIdResponseDto>builder().data(response).customCode(ResponseCode.CREATED).build();
+        return ResponseEntity.created(location).body(responseDto);
+    }
+
+    //수량 변경
+    @PatchMapping("/users/{userId}")
+    public ResponseEntity<ResponseDto<CartIdResponseDto>> patchCart(@PathVariable Long userId, @RequestBody CartPatchRequestDto patch){
+        List<LocalCartDto> request = mapper.toLocalList(patch.getItemList());
+        Cart result = cartService.patchCart(request, userId);
+        CartIdResponseDto response = mapper.toResponseId(result);
+        URI location = UriCreator.createUri("/cart/userId", response.getUserId());
+        ResponseDto<CartIdResponseDto> responseDto = ResponseDto.<CartIdResponseDto>builder().data(response).customCode(ResponseCode.CREATED).build();
+        return ResponseEntity.ok().location(location).body(responseDto);
+    }
+
+    //일부 삭제
+    @PatchMapping("/users/{userId}/del")
+    public ResponseEntity<ResponseDto<CartIdResponseDto>> patchCart(@PathVariable Long userId,@RequestBody CartDeleteDto delete){
+
+        Cart result = cartService.deleteCartItem(userId, delete.getDeleteIdList());
+        CartIdResponseDto response = mapper.toResponseId(result);
+        URI location = UriCreator.createUri("/cart/userId", response.getUserId());
+        ResponseDto<CartIdResponseDto> responseDto = ResponseDto.<CartIdResponseDto>builder().data(response).customCode(ResponseCode.CREATED).build();
+        return ResponseEntity.ok().location(location).body(responseDto);
+    }
+
+    //조회
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<ResponseDto<CartGetResponseDto>> getCart(@PathVariable Long userId){
+        Cart result = cartService.getCart(userId);
+        CartGetResponseDto response = mapper.toGetResponse(result);
+        ResponseDto<CartGetResponseDto> responseDto = ResponseDto.<CartGetResponseDto>builder().data(response).customCode(ResponseCode.OK).build();
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartDeleteDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartDeleteDto.java
@@ -1,0 +1,10 @@
+package project.main.webstore.domain.cart.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CartDeleteDto {
+    private List<Long> deleteIdList;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartGetResponseDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartGetResponseDto.java
@@ -1,0 +1,27 @@
+package project.main.webstore.domain.cart.dto;
+
+import lombok.Getter;
+import project.main.webstore.domain.cart.entity.Cart;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class CartGetResponseDto {
+    private Long cartId;
+    private Long userId;
+    private int deliveryPrice;
+    private int totalPrice;
+    private int discountedPrice;
+    private List<OptionDto> itemList;
+
+    public CartGetResponseDto(Cart cart) {
+        this.cartId = cart.getId();
+        this.userId = cart.getUser().getId();
+        this.itemList = cart.getCartItemList().stream().map(OptionDto::new).collect(Collectors.toList());
+        this.deliveryPrice = cart.getDeliveryPrice();
+        this.totalPrice = cart.getOriginalTotalPrice();
+        this.discountedPrice = cart.getDiscountedTotalPrice();
+    }
+}
+

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartIdResponseDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartIdResponseDto.java
@@ -1,0 +1,13 @@
+package project.main.webstore.domain.cart.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CartIdResponseDto {
+    private Long userId;
+    private Long cartId;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartItemDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartItemDto.java
@@ -1,0 +1,11 @@
+package project.main.webstore.domain.cart.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CartItemDto {
+    private Long optionId;
+    private int itemCount;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartPatchRequestDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartPatchRequestDto.java
@@ -1,0 +1,11 @@
+package project.main.webstore.domain.cart.dto;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class CartPatchRequestDto {
+    private List<CartItemDto> itemList = new ArrayList<>();
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartPostRequestDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/CartPostRequestDto.java
@@ -1,0 +1,12 @@
+package project.main.webstore.domain.cart.dto;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class CartPostRequestDto {
+    private List<CartItemDto> itemList = new ArrayList<>();
+
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/LocalCartDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/LocalCartDto.java
@@ -1,0 +1,13 @@
+package project.main.webstore.domain.cart.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocalCartDto {
+    private Long optionId;
+    private int count;
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/OptionDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/dto/OptionDto.java
@@ -1,0 +1,32 @@
+package project.main.webstore.domain.cart.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.main.webstore.domain.cart.entity.CartItem;
+import project.main.webstore.domain.image.dto.ImageDto;
+
+@Getter
+@NoArgsConstructor
+public class OptionDto {
+    private Long itemId;
+    private Long optionId;
+    private int count;
+    private int defaultPrice;
+    private int additionalPrice;
+    private int discountRate;
+    private String itemName;
+    private String optionName;
+    private ImageDto imageInfo;
+
+    public OptionDto(CartItem entity) {
+        this.itemId = entity.getOption().getItem().getItemId();
+        this.optionId = entity.getOption().getOptionId();
+        this.count = entity.getItemCount();
+        this.defaultPrice = entity.getOption().getItem().getItemPrice().getValue();
+        this.additionalPrice = entity.getOption().getAdditionalPrice();
+        this.discountRate = entity.getOption().getItem().getDiscountRate();
+        this.itemName = entity.getOption().getItem().getItemName();
+        this.optionName = entity.getOption().getOptionDetail();
+        this.imageInfo = new ImageDto(entity.getOption().getItem().getDefaultImage());
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/Cart.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/Cart.java
@@ -59,5 +59,4 @@ public class Cart extends Auditable {
     public Integer getDeliveryPrice(){
         return cartItemList.stream().mapToInt(cartItem -> cartItem.getOption().getItem().getDeliveryPrice().getValue()).max().orElse(0);
     }
-
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/Cart.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/Cart.java
@@ -3,7 +3,11 @@ package project.main.webstore.domain.cart.entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import project.main.webstore.valueObject.Price;
+import lombok.Setter;
+import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.users.entity.User;
+import project.main.webstore.exception.BusinessLogicException;
+import project.main.webstore.exception.CommonExceptionCode;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -13,21 +17,47 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Cart {
+public class Cart extends Auditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(updatable = false)
     private Long id;
-    private int count;
-
-    @Embedded
-    @AttributeOverrides(
-            @AttributeOverride(name="value",column = @Column(name = "DELIVERY_PRICE"))
-    )
-    private Price deliveryPrice;
 
     //양방향 연관계
-    @OneToMany(mappedBy = "cart")
+    @OneToMany(mappedBy = "cart",orphanRemoval = true,cascade = CascadeType.ALL)
+    @Setter
     private List<CartItem> cartItemList = new ArrayList<>();
+
+    @OneToOne(mappedBy = "cart")
+    private User user;
+
+    public Cart(List<CartItem> cartItemList,User user) {
+        this.cartItemList = cartItemList;
+        this.user = user;
+    }
+
+    public Cart(User user) {
+        this.cartItemList = new ArrayList<>();
+        this.user = user;
+    }
+
+    public int getOriginalTotalPrice() {
+        if(cartItemList.isEmpty()){
+            throw new BusinessLogicException(CommonExceptionCode.ITEM_NOT_FOUND);
+        }
+        int cartPrice = cartItemList.stream().mapToInt(CartItem::getTotalPrice).sum();
+        return cartPrice;
+    }
+
+    public int getDiscountedTotalPrice() {
+        if(cartItemList.isEmpty()){
+            throw new BusinessLogicException(CommonExceptionCode.ITEM_NOT_FOUND);
+        }
+        int cartPrice = cartItemList.stream().mapToInt(CartItem::getDiscountedPrice).sum();
+        return cartPrice;
+    }
+    public Integer getDeliveryPrice(){
+        return cartItemList.stream().mapToInt(cartItem -> cartItem.getOption().getItem().getDeliveryPrice().getValue()).max().orElse(0);
+    }
 
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/CartItem.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/entity/CartItem.java
@@ -2,7 +2,8 @@ package project.main.webstore.domain.cart.entity;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import project.main.webstore.domain.item.entity.Item;
+import lombok.Setter;
+import project.main.webstore.domain.item.entity.ItemOption;
 
 import javax.persistence.*;
 
@@ -20,13 +21,36 @@ public class CartItem {
     private Long id;
 
     // 연관관계 매핑 //
+
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "ITEM_ID")
-    private Item item;
+    @JoinColumn(name = "OPTION_ID")
+    private ItemOption option;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "CART_ID")
     private Cart cart;
+    @Setter
+    private Integer itemCount;
 
+    public CartItem(ItemOption option, Cart cart, Integer itemCount) {
+        this.option = option;
+        this.cart = cart;
+        this.itemCount = itemCount;
+    }
 
+    public int getDiscountedPrice() {
+        double itemPrice = this.option.getItem().getItemPrice().getValue() + this.option.getAdditionalPrice();
+        int itemCount = this.itemCount;
+        double discountRate = this.option.getItem().getDiscountRate();
+
+        double totalPrice = (itemPrice * itemCount) * (100 - discountRate) / 100;
+
+        long discountPrice = Math.round(totalPrice);
+
+        return (int) discountPrice;
+    }
+
+    public int getTotalPrice() {
+        return this.itemCount * (this.option.getItem().getItemPrice().getValue() + this.option.getAdditionalPrice());
+    }
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/mapper/CartMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/mapper/CartMapper.java
@@ -1,0 +1,31 @@
+package project.main.webstore.domain.cart.mapper;
+
+import org.springframework.stereotype.Component;
+import project.main.webstore.domain.cart.dto.CartGetResponseDto;
+import project.main.webstore.domain.cart.dto.CartIdResponseDto;
+import project.main.webstore.domain.cart.dto.CartItemDto;
+import project.main.webstore.domain.cart.dto.LocalCartDto;
+import project.main.webstore.domain.cart.entity.Cart;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class CartMapper {
+
+    public LocalCartDto toLocal(CartItemDto post){
+        return new LocalCartDto(post.getOptionId(),post.getItemCount());
+    }
+
+    public List<LocalCartDto> toLocalList(List<CartItemDto> itemList){
+        return itemList.stream().map(this::toLocal).collect(Collectors.toList());
+    }
+
+    public CartIdResponseDto toResponseId(Cart result) {
+        return new CartIdResponseDto(result.getUser().getId(),result.getId());
+    }
+
+    public CartGetResponseDto toGetResponse(Cart result) {
+        return new CartGetResponseDto(result);
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/repository/CartRepository.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/repository/CartRepository.java
@@ -1,0 +1,7 @@
+package project.main.webstore.domain.cart.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.main.webstore.domain.cart.entity.Cart;
+
+public interface CartRepository extends JpaRepository<Cart,Long> {
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/cart/service/CartService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/cart/service/CartService.java
@@ -1,0 +1,86 @@
+package project.main.webstore.domain.cart.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.main.webstore.domain.cart.dto.LocalCartDto;
+import project.main.webstore.domain.cart.entity.Cart;
+import project.main.webstore.domain.cart.entity.CartItem;
+import project.main.webstore.domain.cart.repository.CartRepository;
+import project.main.webstore.domain.item.entity.ItemOption;
+import project.main.webstore.domain.item.service.OptionService;
+import project.main.webstore.domain.users.entity.User;
+import project.main.webstore.domain.users.service.UserValidService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CartService {
+    private final CartRepository cartRepository;
+    private final UserValidService userValidService;
+    private final OptionService optionService;
+
+    //처음이나 추가 모두 여기 들어가게 된다.
+    public Cart postCart(List<LocalCartDto> itemList, Long userId) {
+        User findUser = userValidService.validUser(userId);
+
+        List<Long> optionIdList = itemList.stream().map(LocalCartDto::getOptionId).collect(Collectors.toList());
+
+        List<ItemOption> optionList = optionService.getOptions(optionIdList);
+
+        if (findUser.getCart() == null) {
+            findUser.setCart(new Cart(findUser));
+        }
+        Cart cart = findUser.getCart();
+        List<CartItem> findCartItem = cart.getCartItemList();
+
+        for(int i = 0 ; i < optionList.size(); i++){
+            CartItem cartItem = new CartItem(optionList.get(i), cart, itemList.get(i).getCount());
+            findCartItem.add(cartItem);
+        }
+
+        return cart;
+    }
+
+    public Cart getCart(Long userId) {
+        User findUser = userValidService.validUser(userId);
+        Cart cart = findUser.getCart();
+
+        return cart;
+    }
+
+    public void deleteCart(Long userId) {
+        User user = userValidService.validUser(userId);
+        Cart cart = user.getCart();
+        cartRepository.delete(cart);
+    }
+
+    //수량 변경
+    public Cart patchCart(List<LocalCartDto> patch, Long userId) {
+        User findUser = userValidService.validUser(userId);
+        Cart cart = findUser.getCart();
+
+        for (LocalCartDto localCartDto : patch) {
+            for (CartItem cartItem : cart.getCartItemList()) {
+                if (localCartDto.getOptionId() == cartItem.getOption().getOptionId()) {
+                    cartItem.setItemCount(localCartDto.getCount());
+                    break;
+                }
+            }
+        }
+        return cart;
+    }
+
+    //취소 하고 싶은 것들 리스트 -> CartItemList 들로 표현한다.
+    public Cart deleteCartItem(Long userId, List<Long> deleteIdList) {
+        Cart cart = userValidService.validUser(userId).getCart();
+        List<CartItem> cartItemList = cart.getCartItemList();
+        List<CartItem> collect = cartItemList.stream().filter(cartItem -> !deleteIdList.contains(cartItem.getOption().getOptionId())).collect(Collectors.toList());
+        cart.setCartItemList(collect);
+        return cart;
+    }
+
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemPatchDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemPatchDto.java
@@ -28,7 +28,7 @@ public class ItemPatchDto {
     private Integer itemPrice;
     @Schema(description = "배달 가격",example = "3000")
     private Integer deliveryPrice;
-
+    private int discountRate;
 
     //이미지 삭제 로직
     @Schema(description = "삭제할 이미지의 ID 리스트")

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemPostDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemPostDto.java
@@ -24,9 +24,7 @@ public class ItemPostDto {
     @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s]*$")
     @Schema(description = "상품 이름",example = "맥북")
     private String name;
-    @NotNull
-    @Schema(description = "옵션이 없는 기본상품 수량",example = "10")
-    private int defaultCount;
+    private int discountRate;
     @NotNull
     @Pattern(regexp = "^[가-힣a-zA-Z\\d`~!@#$%^&*()-_=+\\s]*$")
     @Schema(description = "상품 설명",defaultValue = "상품에 대한 상세 설명")

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import project.main.webstore.audit.Auditable;
 import project.main.webstore.domain.cart.entity.CartItem;
+import project.main.webstore.domain.image.entity.Image;
 import project.main.webstore.domain.image.entity.ItemImage;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
@@ -43,7 +44,7 @@ public class Item extends Auditable {
     @Column(nullable = false)
     @Setter
     private String itemName;
-//    @Column(nullable = false)
+    //    @Column(nullable = false)
 //    @Setter
 //    private Integer defaultCount;
     @Lob
@@ -78,21 +79,21 @@ public class Item extends Auditable {
     private Category category;
 
     // 연관관계 매핑 //
-    @OneToMany(mappedBy = "item",orphanRemoval = true,cascade = ALL)
+    @OneToMany(mappedBy = "item", orphanRemoval = true, cascade = ALL)
     private List<ItemSpec> specList = new ArrayList<>();
-    @OneToMany(mappedBy = "item",orphanRemoval = true,cascade = ALL)
+    @OneToMany(mappedBy = "item", orphanRemoval = true, cascade = ALL)
     private List<ItemOption> optionList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "item",cascade = ALL)
+    @OneToMany(cascade = ALL)
     private List<CartItem> cartItemList = new ArrayList<>();
-    @OneToMany(mappedBy = "item",cascade = ALL)
+    @OneToMany(mappedBy = "item", cascade = ALL)
     private List<OrderItem> orderItemList = new ArrayList<>();
-    @OneToMany(mappedBy = "item",cascade = ALL,orphanRemoval = true)
+    @OneToMany(mappedBy = "item", cascade = ALL, orphanRemoval = true)
     private List<Review> reviewList = new ArrayList<>();
-    @OneToMany(mappedBy = "item",cascade = ALL,orphanRemoval = true)
+    @OneToMany(mappedBy = "item", cascade = ALL, orphanRemoval = true)
     private List<Question> questionList = new ArrayList<>();
     //PickedItem 연관관계 매핑
-    @OneToMany(fetch = LAZY,cascade = ALL,mappedBy = "item")
+    @OneToMany(fetch = LAZY, cascade = ALL, mappedBy = "item")
     private List<PickedItem> pickedItem;
 
     @OneToOne(cascade = ALL)
@@ -111,16 +112,17 @@ public class Item extends Auditable {
         this.discountRate = post.getDiscountRate();
         this.itemPrice = Price.builder().value(post.getItemPrice()).build();
         this.deliveryPrice = Price.builder().value(post.getDeliveryPrice()).build();
-        this.defaultItem = new ItemOption(0,post.getItemPrice(),this);
+        this.defaultItem = new ItemOption(0, post.getItemPrice(), this);
         this.category = post.getCategory();
-        this.specList = post.getSpecList() != null ? post.getSpecList().stream().map(spec -> new ItemSpec(spec.getName(),spec.getContent(),this)).collect(Collectors.toList()) : null;
-        this.optionList = post.getOptionList() != null ? post.getOptionList().stream().map(option -> new ItemOption(option.getOptionDetail(),option.getItemCount(),option.getAdditionalPrice(),this)).collect(Collectors.toList()) : null;
+        this.specList = post.getSpecList() != null ? post.getSpecList().stream().map(spec -> new ItemSpec(spec.getName(), spec.getContent(), this)).collect(Collectors.toList()) : null;
+        this.optionList = post.getOptionList() != null ? post.getOptionList().stream().map(option -> new ItemOption(option.getOptionDetail(), option.getItemCount(), option.getAdditionalPrice(), this)).collect(Collectors.toList()) : null;
     }
+
     public Item(ItemPatchDto patch) {
         this.itemName = patch.getName();
         this.description = patch.getDescription();
         this.discountRate = patch.getDiscountRate();
-        this.defaultItem = new ItemOption(0,patch.getDefaultCount(),this);
+        this.defaultItem = new ItemOption(0, patch.getDefaultCount(), this);
         this.deliveryPrice = Price.builder().value(patch.getDeliveryPrice()).build();
         this.category = patch.getCategory();
     }
@@ -167,11 +169,11 @@ public class Item extends Auditable {
         image.setItem(this);
     }
 
-    public int getTotalPrice(){
-        if(optionList.isEmpty()){
+    public int getTotalPrice() {
+        if (optionList.isEmpty()) {
             return 0;
         }
-       return this.optionList.stream().mapToInt(ItemOption::getItemCount).sum();
+        return this.optionList.stream().mapToInt(ItemOption::getItemCount).sum();
     }
 
     // Price Method
@@ -179,19 +181,23 @@ public class Item extends Auditable {
         this.itemPrice = itemPrice;
         this.deliveryPrice = deliveryPrice;
     }
-    
-//    public int getTotalCount(){
+
+    //    public int getTotalCount(){
 //        if(this.optionList.isEmpty()){
 //            return defaultCount;
 //        }
 //        int totalOptionCount = optionList.stream().mapToInt(option -> option.getItemCount()).sum();
 //        return defaultCount + totalOptionCount;
 //    }
-    public int getTotalCount(){
-        if(this.optionList.isEmpty()){
+    public int getTotalCount() {
+        if (this.optionList.isEmpty()) {
             return 0;
         }
         return optionList.stream().mapToInt(ItemOption::getItemCount).sum();
+    }
+
+    public ItemImage getDefaultImage() {
+        return itemImageList.stream().filter(Image::isRepresentative).findFirst().get();
     }
 }
 

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
@@ -43,9 +43,9 @@ public class Item extends Auditable {
     @Column(nullable = false)
     @Setter
     private String itemName;
-    @Column(nullable = false)
-    @Setter
-    private Integer defaultCount;
+//    @Column(nullable = false)
+//    @Setter
+//    private Integer defaultCount;
     @Lob
     @Setter
     private String description;

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/ItemOption.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/ItemOption.java
@@ -54,4 +54,10 @@ public class ItemOption {
         this.itemCount = itemCount;
         this.additionalPrice = additionalPrice;
     }
+
+    public ItemOption(int additionalPrice, Integer itemCount, Item item) {
+        this.additionalPrice = additionalPrice;
+        this.itemCount = itemCount;
+        this.item = item;
+    }
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/repository/OptionRepository.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/repository/OptionRepository.java
@@ -10,4 +10,7 @@ import java.util.List;
 public interface OptionRepository extends JpaRepository<ItemOption, Long> {
     @Query("SELECT i FROM ItemOption i WHERE i.item.itemId = :itemId")
     List<ItemOption> findAllByItemId(@Param("itemId") Long itemId);
+
+    @Query("SELECT i FROM ItemOption i WHERE i.optionId in :optionIdList")
+    List<ItemOption> findInId(@Param("optionIdList")List<Long> optionIdList);
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/service/ItemService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/service/ItemService.java
@@ -60,8 +60,9 @@ public class ItemService {
 
         Optional.ofNullable(item.getCategory()).ifPresent(findItem::setCategory);
         Optional.ofNullable(item.getItemName()).ifPresent(findItem::setItemName);
-        Optional.ofNullable(item.getDefaultCount()).ifPresent(findItem::setDefaultCount);
+        Optional.ofNullable(item.getDiscountRate()).ifPresent(findItem::setDiscountRate);
         Optional.ofNullable(item.getDescription()).ifPresent(findItem::setDescription);
+        Optional.ofNullable(item.getDefaultItem()).ifPresent(findItem::setDefaultItem);
         Optional.ofNullable(item.getItemPrice()).ifPresent(findItem::setItemPrice);
         Optional.ofNullable(item.getDeliveryPrice()).ifPresent(findItem::setDeliveryPrice);
 

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/service/OptionService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/service/OptionService.java
@@ -50,7 +50,9 @@ public class OptionService {
     public ItemOption getOption(Long optionId) {
         return findVerifiedOption(optionId);
     }
-
+    public List<ItemOption> getOptions(List<Long> optionId){
+        return optionRepository.findInId(optionId);
+    }
     public List<ItemOption> getOptions(Long itemId) {
         return optionRepository.findAllByItemId(itemId);
     }

--- a/BE/backend/src/main/java/project/main/webstore/domain/qna/service/QnaService.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/qna/service/QnaService.java
@@ -34,7 +34,6 @@ public class QnaService {
 
         Optional.ofNullable(request.getQnaStatus()).ifPresent(find::setQnaStatus);
         Optional.ofNullable(request.getComment()).ifPresent(find::setComment);
-        find.setSecret(request.isSecret());
 
         return find;
     }

--- a/BE/backend/src/main/java/project/main/webstore/domain/users/entity/User.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/users/entity/User.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import project.main.webstore.audit.Auditable;
+import project.main.webstore.domain.cart.entity.Cart;
 import project.main.webstore.domain.item.entity.PickedItem;
 import project.main.webstore.domain.users.dto.UserPatchRequestDto;
 import project.main.webstore.domain.users.dto.UserPostRequestDto;
@@ -20,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static javax.persistence.EnumType.STRING;
+import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -55,6 +57,9 @@ public class User extends Auditable implements Principal {
 
     @OneToMany(mappedBy = "user")
     private List<PickedItem> pickedItemList;
+    @OneToOne(fetch = LAZY,cascade = CascadeType.ALL)
+    @JoinColumn(name = "CART_ID")
+    private Cart cart;
 
     @Override
     public String getName() {

--- a/BE/backend/src/main/java/project/main/webstore/exception/CommonExceptionCode.java
+++ b/BE/backend/src/main/java/project/main/webstore/exception/CommonExceptionCode.java
@@ -27,7 +27,7 @@ public enum CommonExceptionCode implements ExceptionCode {
     SPEC_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 스펙이 존재하지 않습니다."),
     OPTION_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 옵션이 존재하지 않습니다."),
 
-    COVERT_ERROR(HttpStatus.BAD_REQUEST, "변환 실패 요청을 확인하시오");
+    COVERT_ERROR(HttpStatus.BAD_REQUEST, "변환 실패 요청을 확인하시오"), ITEM_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "재고 부족");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
# 작업 내용
1. 장바구니 엔티티 수정(연관관계 수정)
2. API,Service, Repository 구현

# 작업 회고
* 기존의 코드는 Item과 ItemOption을 동시에 받아서 장바구니를 처리했다.
     * 단점
          1. 참조의 복잡성 [연관관계가 복잡하다]
          2. 데이터 수정 시 item을 찾고 option을 찾아야한다. [로직의 복잡성]
      * 수정
          1. option에 기본 옵션을 추가, option만 장바구니에 의존시켜 로직을 간단하게 구현
* 기본 option 연관관계를 item에 매핑
       * 같은 연관관계를 2번 매핑하면 작동을 할 수 있는가에 대한 것에 대한 생각 및 엔티티를 연관관계 매핑하는 이유에 대한 생각을 한 후 같은 엔티티를 2번 매핑해도 상관없다고 판단
