### PR TITLE
상품 수정 페이지 구현 및 상품 등록 페이지, 메인(랜딩) 페이지 수정

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -72,7 +72,7 @@ function App() {
           <Route path="productlist" element={<ProductList />} />
           <Route path="productinquiry" element={<ProductInquiry />} />
           <Route path="productlist/post" element={<ProductPost />} />
-          <Route path="productlist/edit" element={<ProductEdit />} />
+          <Route path="productlist/edit/:id" element={<ProductEdit />} />
           <Route path="reviewmanagement" element={<ReviewManagement />} />
           <Route path="orderedlist" element={<OrderedList />} />
           <Route path="sales" element={<Sales />} />

--- a/FE/src/Components/LSM/Main/BestProduct/BestItem.tsx
+++ b/FE/src/Components/LSM/Main/BestProduct/BestItem.tsx
@@ -8,6 +8,7 @@ interface BestItemProps {
   price: string;
   image: string;
   idx: number;
+  currentPage: number;
 }
 
 export default function BestItem({
@@ -17,12 +18,13 @@ export default function BestItem({
   price,
   image,
   idx,
+  currentPage,
 }: BestItemProps) {
   const backgroundImage = {
     backgroundImage: `url('${image}')`,
   };
   const noneBackgroundImage = {
-    backgroundImage: `url('https://source.unsplash.com/random')`,
+    backgroundImage: `url('https://images.unsplash.com/photo-1531297484001-80022131f5a1?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=3440&q=80')`,
   };
 
   const navigate = useNavigate();
@@ -43,7 +45,7 @@ export default function BestItem({
         style={image !== undefined ? backgroundImage : noneBackgroundImage}
       >
         <div className="flex items-center justify-center w-12 h-12 font-semibold text-white rounded-br-lg bg-box-black">
-          {id}
+          {idx + 1 + currentPage * 4}
         </div>
       </div>
       <BestItemInfo title={title} category={category} price={price} />

--- a/FE/src/Components/LSM/Main/BestProduct/BestItemList.tsx
+++ b/FE/src/Components/LSM/Main/BestProduct/BestItemList.tsx
@@ -70,6 +70,7 @@ export default function BestItemList({ bestItemsData }: BestItemListProps) {
               price={item.itemPrice}
               image={item?.imageList[idx]?.thumbnailPath}
               idx={idx}
+              currentPage={currentPage}
             />
           ))}
         </div>

--- a/FE/src/Components/LSM/Main/BestReview/ReviewItem.tsx
+++ b/FE/src/Components/LSM/Main/BestReview/ReviewItem.tsx
@@ -32,7 +32,11 @@ export default function ReviewItem({
       >
         <img
           className="object-cover w-full h-48 rounded-tl-2xl rounded-tr-2xl"
-          src={image !== null ? image : 'https://source.unsplash.com/random'}
+          src={
+            image !== null
+              ? image
+              : 'https://images.unsplash.com/photo-1531297484001-80022131f5a1?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=3440&q=80'
+          }
           alt="리뷰 이미지"
         />
         <div className="flex items-center justify-start w-full h-32 px-4">

--- a/FE/src/Components/LSM/Main/NewProduct/NewItem.tsx
+++ b/FE/src/Components/LSM/Main/NewProduct/NewItem.tsx
@@ -8,6 +8,7 @@ interface NewItemProps {
   price: string;
   image: string;
   idx: number;
+  currentPage: number;
 }
 
 export default function NewItem({
@@ -17,12 +18,13 @@ export default function NewItem({
   price,
   image,
   idx,
+  currentPage,
 }: NewItemProps) {
   const backgroundImage = {
     backgroundImage: `url('${image}')`,
   };
   const noneBackgroundImage = {
-    backgroundImage: `url('https://source.unsplash.com/random')`,
+    backgroundImage: `url('https://images.unsplash.com/photo-1531297484001-80022131f5a1?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=3440&q=80')`,
   };
 
   const navigate = useNavigate();
@@ -43,7 +45,7 @@ export default function NewItem({
         style={image !== undefined ? backgroundImage : noneBackgroundImage}
       >
         <div className="flex items-center justify-center w-12 h-12 font-semibold text-white rounded-br-lg bg-box-black">
-          {id}
+          {idx + 1 + currentPage * 4}
         </div>
       </div>
       <NewItemInfo title={title} category={category} price={price} />

--- a/FE/src/Components/LSM/Main/NewProduct/NewItemList.tsx
+++ b/FE/src/Components/LSM/Main/NewProduct/NewItemList.tsx
@@ -70,6 +70,7 @@ export default function NewItemList({ newItemsData }: NewItemListProps) {
               price={item.itemPrice}
               image={item?.imageList[idx]?.thumbnailPath}
               idx={idx}
+              currentPage={currentPage}
             />
           ))}
         </div>

--- a/FE/src/Components/LSM/Main/ThemeProduct/ThemeItem.tsx
+++ b/FE/src/Components/LSM/Main/ThemeProduct/ThemeItem.tsx
@@ -18,7 +18,7 @@ export default function ThemeItem({
     backgroundImage: `url('${image}')`,
   };
   const noneBackgroundImage = {
-    backgroundImage: `url('https://source.unsplash.com/random')`,
+    backgroundImage: `url('https://images.unsplash.com/photo-1531297484001-80022131f5a1?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=3440&q=80')`,
   };
 
   const navigate = useNavigate();

--- a/FE/src/Components/LSM/Product/ProductForm/Button.tsx
+++ b/FE/src/Components/LSM/Product/ProductForm/Button.tsx
@@ -2,10 +2,10 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 interface ProductProp {
   postData: any;
-  // patchData: any;
+  patchData: any;
 }
 
-export default function Button({ postData }: ProductProp) {
+export default function Button({ postData, patchData }: ProductProp) {
   const navigate = useNavigate();
   const prevHandler = () => {
     navigate('/admin/productlist');
@@ -46,7 +46,7 @@ export default function Button({ postData }: ProductProp) {
               type={btn.name === '취소' ? 'button' : 'submit'}
               key={btn.id}
               className={classnames}
-              onClick={btn.name === '취소' ? prevHandler : prevHandler}
+              onClick={btn.name === '취소' ? prevHandler : patchData}
             >
               {btn.name}
             </button>

--- a/FE/src/Components/LSM/Product/ProductForm/CategoryInput.tsx
+++ b/FE/src/Components/LSM/Product/ProductForm/CategoryInput.tsx
@@ -1,22 +1,36 @@
+import { useEffect } from 'react';
 import Select from './Select';
 
 interface ProductProp {
-  // datas: any;
-  // path: string;
-  category: string;
+  datas: any;
+  pathName: string;
   setCategory: React.Dispatch<React.SetStateAction<string>>;
-  // setEditCategory: React.Dispatch<React.SetStateAction<string>>;
-  // editCategory: string;
-  // id: string;
+  setEditCategory: React.Dispatch<React.SetStateAction<string>>;
+  editCategory: string;
 }
 
-export default function CategoryInput({ category, setCategory }: ProductProp) {
+export default function CategoryInput({
+  datas,
+  pathName,
+  setCategory,
+  editCategory,
+  setEditCategory,
+}: ProductProp) {
+  useEffect(() => {
+    setEditCategory(datas?.category);
+  }, [datas?.category]);
+
   return (
     <div className="flex items-center mt-8">
       <label htmlFor="productTitle" className="w-20 text-label-gray">
         카테고리
       </label>
-      <Select category={category} setCategory={setCategory} />
+      <Select
+        pathName={pathName}
+        setCategory={setCategory}
+        editCategory={editCategory}
+        setEditCategory={setEditCategory}
+      />
     </div>
   );
 }

--- a/FE/src/Components/LSM/Product/ProductForm/ImageInput.tsx
+++ b/FE/src/Components/LSM/Product/ProductForm/ImageInput.tsx
@@ -7,6 +7,8 @@ interface ImageInputProp {
   setImagePreview: React.Dispatch<React.SetStateAction<any>>;
   images: any;
   setImages: React.Dispatch<React.SetStateAction<any>>;
+  editImages: any;
+  setEditImages: React.Dispatch<React.SetStateAction<any>>;
 }
 
 export default function ImageInput({
@@ -14,6 +16,8 @@ export default function ImageInput({
   setImagePreview,
   images,
   setImages,
+  editImages,
+  setEditImages,
 }: ImageInputProp) {
   const [isRepresentative, setIsRepresentative] = useState<boolean[]>([
     false,
@@ -32,12 +36,12 @@ export default function ImageInput({
       if (imageIdx === idx) {
         return {
           ...image,
-          representative: true, // 현재 이미지를 true로 설정
+          representative: true,
         };
       } else {
         return {
           ...image,
-          representative: false, // 다른 이미지들을 false로 설정
+          representative: false,
         };
       }
     });

--- a/FE/src/Components/LSM/Product/ProductForm/OptionInput.tsx
+++ b/FE/src/Components/LSM/Product/ProductForm/OptionInput.tsx
@@ -1,101 +1,272 @@
+import { useEffect } from 'react';
 import { AiOutlineMinus } from 'react-icons/ai';
+import { useSelector } from 'react-redux';
+import type { StoreType } from 'model/redux';
 
 interface ProductProp {
+  datas: any;
+  pathName: string;
   options: any;
   setOptions: React.Dispatch<React.SetStateAction<any>>;
   setDefaultCount: React.Dispatch<React.SetStateAction<any>>;
+  editOptions: any;
+  setEditOptions: React.Dispatch<React.SetStateAction<any>>;
+  deleteOptions: number[];
+  setDeleteOptions: React.Dispatch<React.SetStateAction<any>>;
 }
 
 export default function OptionInput({
+  datas,
+  pathName,
   options,
   setOptions,
   setDefaultCount,
+  editOptions,
+  setEditOptions,
+  deleteOptions,
+  setDeleteOptions,
 }: ProductProp) {
+  const getOptionId = useSelector((e: StoreType) => e.currentOptionId);
+
   const addInputHandler = () => {
-    setOptions([
-      ...options,
-      { optionName: '', itemCount: 0, optionDetail: '', additionalPrice: 0 },
-    ]);
+    if (pathName === 'post') {
+      setOptions([
+        ...options,
+        {
+          itemCount: 0,
+          optionDetail: '',
+          additionalPrice: 0,
+        },
+      ]);
+    } else {
+      setEditOptions([
+        ...editOptions,
+        {
+          optionId: null,
+          itemCount: 0,
+          optionDetail: '',
+          additionalPrice: 0,
+        },
+      ]);
+    }
   };
 
-  const removeInputHandler = (idx: number) => {
-    const filteredInputs = [...options];
-    filteredInputs.splice(idx, 1);
-    setOptions(filteredInputs);
+  const removeInputHandler = (idx: number, getOptionId: any) => {
+    const filteredOption = getOptionId.filter(
+      (option: number, index: number) => {
+        return idx === index;
+      }
+    );
+    if (pathName === 'edit') {
+      const filteredEditInputs = [...editOptions];
+      filteredEditInputs.splice(idx, 1);
+      const filteredOptionId: number = filteredOption[0]?.optionId;
+      if (filteredOptionId !== undefined) {
+        deleteOptions.push(filteredOptionId);
+        setDeleteOptions(deleteOptions);
+      } else {
+        setDeleteOptions(null);
+      }
+      if (deleteOptions === null || deleteOptions.length === 0) {
+        setDeleteOptions(null);
+      }
+      setEditOptions(filteredEditInputs);
+    } else {
+      const filteredInputs = [...options];
+      filteredInputs.splice(idx, 1);
+      setOptions(filteredInputs);
+    }
   };
 
   const onChangeHandler = (
     idx: number,
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    const list = [...options] as any;
-    list[idx][e.target.id] = e.target.value;
-    setOptions(list);
+    if (pathName === 'post') {
+      const list = [...options] as any;
+      list[idx][e.target.id] = e.target.value;
 
-    const itemCounts = list.map((item: any) => parseInt(item.itemCount));
-    const totalItemCount = itemCounts.reduce(
-      (acc: number, cur: number) => acc + cur,
-      0
-    );
+      const itemCounts = list.map((item: any) => parseInt(item.itemCount));
+      const totalItemCount = itemCounts.reduce(
+        (acc: number, cur: number) => acc + cur,
+        0
+      );
+      setOptions(list);
+      setDefaultCount(totalItemCount);
+    } else {
+      const editList = [...editOptions] as any;
+      editList[idx][e.target.id] = e.target.value;
 
-    setDefaultCount(totalItemCount);
+      const editItemCounts = editList.map((item: any) =>
+        parseInt(item.itemCount)
+      );
+      const totalEditItemCount = editItemCounts.reduce(
+        (acc: number, cur: number) => acc + cur,
+        0
+      );
+      setEditOptions(editList);
+      setDefaultCount(totalEditItemCount);
+      console.log(editList);
+    }
   };
+
+  useEffect(() => {
+    if (datas?.optionList !== null) {
+      setEditOptions(datas?.optionList);
+    }
+  }, [datas]);
 
   return (
     <div className="w-full my-20">
       <p className="mb-6 text-subtitle-gray">옵션 등록</p>
-      {options.map((item: any, idx: number) => {
-        return (
-          <div key={idx} className="flex flex-col items-start justify-between">
-            <div className="flex items-center w-full mb-8">
-              <label htmlFor="optionName" className="w-24 mr-4 text-label-gray">
-                옵션 {idx + 1}
-              </label>
-              <input
-                id="optionName"
-                name="optionName"
-                type="text"
-                placeholder="옵션을 입력해 주세요"
-                onChange={(e) => {
-                  onChangeHandler(idx, e);
-                }}
-                className="w-full px-5 py-3 border rounded-3xl border-gray"
-              />
-              <label htmlFor="itemCount">{}</label>
-              <input
-                id="itemCount"
-                name="itemCount"
-                type="text"
-                placeholder="옵션 수량 (숫자만 입력)"
-                onChange={(e) => {
-                  onChangeHandler(idx, e);
-                }}
-                className="px-5 py-3 ml-4 border rounded-3xl border-gray"
-              />
-              {options.length > 1 && (
+      {pathName === 'post' &&
+        options?.map((option: any, idx: number) => {
+          return (
+            <div
+              key={idx}
+              className="flex flex-col items-start justify-between"
+            >
+              <div className="flex items-center w-full mb-8">
+                <div className="flex flex-col w-full">
+                  <p className="mb-2 text-label-gray">옵션 {idx + 1}</p>
+                  <label htmlFor="optionDetail" />
+                  <input
+                    id="optionDetail"
+                    name="optionDetail"
+                    type="text"
+                    placeholder="옵션 내용 (ex. 색상, 사이즈)"
+                    onChange={(e) => {
+                      onChangeHandler(idx, e);
+                    }}
+                    className="w-full px-5 py-3 mb-2 border rounded-3xl border-gray"
+                  />
+                  <label htmlFor="additionalPrice" />
+                  <input
+                    id="additionalPrice"
+                    name="additionalPrice"
+                    type="text"
+                    placeholder="추가 금액 (숫자만 입력)"
+                    onChange={(e) => {
+                      onChangeHandler(idx, e);
+                    }}
+                    className="w-full px-5 py-3 mb-2 border rounded-3xl border-gray"
+                  />
+                  <label htmlFor="itemCount" />
+                  <input
+                    id="itemCount"
+                    name="itemCount"
+                    type="text"
+                    placeholder="옵션 수량 (숫자만 입력)"
+                    onChange={(e) => {
+                      onChangeHandler(idx, e);
+                    }}
+                    className="px-5 py-3 mb-2 border rounded-3xl border-gray"
+                  />
+                </div>
+                {options?.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      removeInputHandler(idx, getOptionId);
+                    }}
+                    className="flex items-center justify-center p-4 ml-4 border rounded-full"
+                  >
+                    <AiOutlineMinus />
+                  </button>
+                )}
+              </div>
+              {options?.length - 1 === idx && options?.length < 10 && (
                 <button
                   type="button"
-                  onClick={() => {
-                    removeInputHandler(idx);
-                  }}
-                  className="flex items-center justify-center p-4 ml-4 border rounded-full"
+                  onClick={addInputHandler}
+                  className="px-10 py-3 text-sm border rounded-3xl"
                 >
-                  <AiOutlineMinus />
+                  옵션추가하기 +
                 </button>
               )}
             </div>
-            {options.length - 1 === idx && options.length < 10 && (
-              <button
-                type="button"
-                onClick={addInputHandler}
-                className="px-10 py-3 text-sm border rounded-3xl"
-              >
-                옵션추가하기 +
-              </button>
-            )}
-          </div>
-        );
-      })}
+          );
+        })}
+      {pathName === 'edit' &&
+        editOptions?.map((option: any, idx: number) => {
+          return (
+            <div
+              key={idx}
+              className="flex flex-col items-start justify-between"
+            >
+              <div className="flex items-center w-full mb-8">
+                <div className="flex flex-col w-full">
+                  <p id="optionName" className="mb-2 text-label-gray">
+                    옵션 {idx + 1}
+                  </p>
+                  <label htmlFor="optionDetail" />
+                  <input
+                    id="optionDetail"
+                    name="optionDetail"
+                    type="text"
+                    placeholder="옵션 내용 (ex. 블랙, XL)"
+                    onChange={(e) => {
+                      onChangeHandler(idx, e);
+                    }}
+                    value={
+                      option?.optionDetail === null ? '' : option.optionDetail
+                    }
+                    className="w-full px-5 py-3 mb-2 border rounded-3xl border-gray"
+                  />
+                  <label htmlFor="additionalPrice" />
+                  <input
+                    id="additionalPrice"
+                    name="additionalPrice"
+                    type="text"
+                    placeholder="추가 금액 (숫자만 입력)"
+                    onChange={(e) => {
+                      onChangeHandler(idx, e);
+                    }}
+                    value={
+                      option?.additionalPrice === null
+                        ? ''
+                        : option.additionalPrice
+                    }
+                    className="w-full px-5 py-3 mb-2 border rounded-3xl border-gray"
+                  />
+                  <label htmlFor="itemCount" />
+                  <input
+                    id="itemCount"
+                    name="itemCount"
+                    type="text"
+                    placeholder="옵션 수량 (숫자만 입력)"
+                    onChange={(e) => {
+                      onChangeHandler(idx, e);
+                    }}
+                    value={option?.itemCount}
+                    className="px-5 py-3 border rounded-3xl border-gray"
+                  />
+                </div>
+
+                {editOptions?.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      removeInputHandler(idx, getOptionId);
+                    }}
+                    className="flex items-center justify-center p-4 ml-4 border rounded-full"
+                  >
+                    <AiOutlineMinus />
+                  </button>
+                )}
+              </div>
+              {editOptions?.length - 1 === idx && editOptions?.length < 10 && (
+                <button
+                  type="button"
+                  onClick={addInputHandler}
+                  className="px-10 py-3 text-sm border rounded-3xl"
+                >
+                  옵션추가하기 +
+                </button>
+              )}
+            </div>
+          );
+        })}
     </div>
   );
 }

--- a/FE/src/Components/LSM/Product/ProductForm/OrderInput.tsx
+++ b/FE/src/Components/LSM/Product/ProductForm/OrderInput.tsx
@@ -1,49 +1,95 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import CheckBox from './CheckBox';
 interface ProductProp {
+  datas: any;
+  pathName: string;
   deliveryPrice: any;
   setDeliveryPrice: React.Dispatch<React.SetStateAction<any>>;
+  setEditDeliveryPrice: React.Dispatch<React.SetStateAction<any>>;
 }
 
 export default function OrderInput({
+  datas,
+  pathName,
   deliveryPrice,
   setDeliveryPrice,
+  setEditDeliveryPrice,
 }: ProductProp) {
-  const [isFree, setIsFree] = useState<boolean>(true);
+  const [isFree, setIsFree] = useState<boolean>(false);
 
   const onChangeHandler = (e: any) => {
     const newDeliveredPrice = e.target.value;
-    setDeliveryPrice(parseInt(newDeliveredPrice));
-    if (newDeliveredPrice === '' || isNaN(parseInt(newDeliveredPrice))) {
-      setDeliveryPrice(0);
-    }
-    if (newDeliveredPrice === '' || parseInt(newDeliveredPrice) === 0) {
-      setIsFree(true);
+    if (pathName === 'post') {
+      setDeliveryPrice(parseInt(newDeliveredPrice));
+      if (newDeliveredPrice === '' || isNaN(parseInt(newDeliveredPrice))) {
+        setDeliveryPrice(0);
+      }
+      if (newDeliveredPrice === '' || parseInt(newDeliveredPrice) === 0) {
+        setIsFree(true);
+      } else {
+        setIsFree(false);
+      }
     } else {
-      setIsFree(false);
+      setEditDeliveryPrice(parseInt(newDeliveredPrice));
+      if (newDeliveredPrice === '' || isNaN(parseInt(newDeliveredPrice))) {
+        setEditDeliveryPrice(0);
+      }
+      if (newDeliveredPrice === '' || parseInt(newDeliveredPrice) === 0) {
+        setIsFree(true);
+      } else {
+        setIsFree(false);
+      }
     }
   };
+
+  useEffect(() => {
+    if (datas?.deliveryPrice !== undefined) {
+      setEditDeliveryPrice(datas?.deliveryPrice);
+    }
+  }, [datas]);
 
   return (
     <div className="w-full">
       <p className="mb-6 text-subtitle-gray">배송정보</p>
-      <div className="flex items-center w-full">
-        <div className="flex items-center w-full">
-          <label htmlFor="productOrder" className="w-20 text-label-gray">
-            배송비
-          </label>
-          <input
-            id="productOrder"
-            type="text"
-            placeholder="숫자만 입력해 주세요 (원 단위)"
-            className="w-full px-5 py-3 border rounded-3xl border-gray"
-            onChange={onChangeHandler}
-            disabled={isFree}
-            value={deliveryPrice}
-          />
-        </div>
-        <CheckBox isFree={isFree} setIsFree={setIsFree} />
-      </div>
+      <>
+        {pathName === 'post' ? (
+          <div className="flex items-center w-full">
+            <div className="flex items-center w-full">
+              <label htmlFor="productOrder" className="w-20 text-label-gray">
+                배송비
+              </label>
+              <input
+                id="productOrder"
+                type="text"
+                placeholder="숫자만 입력해 주세요 (원 단위)"
+                className="w-full px-5 py-3 border rounded-3xl border-gray"
+                onChange={onChangeHandler}
+                disabled={isFree}
+                value={deliveryPrice}
+              />
+            </div>
+            <CheckBox isFree={isFree} setIsFree={setIsFree} />
+          </div>
+        ) : (
+          <div className="flex items-center w-full">
+            <div className="flex items-center w-full">
+              <label htmlFor="productOrder" className="w-20 text-label-gray">
+                배송비
+              </label>
+              <input
+                id="productOrder"
+                type="text"
+                placeholder="숫자만 입력해 주세요 (원 단위)"
+                className="w-full px-5 py-3 border rounded-3xl border-gray"
+                onChange={onChangeHandler}
+                disabled={isFree}
+                defaultValue={datas.deliveryPrice}
+              />
+            </div>
+            <CheckBox isFree={isFree} setIsFree={setIsFree} />
+          </div>
+        )}
+      </>
     </div>
   );
 }

--- a/FE/src/Components/LSM/Product/ProductForm/PriceInput.tsx
+++ b/FE/src/Components/LSM/Product/ProductForm/PriceInput.tsx
@@ -1,26 +1,59 @@
+import { useEffect } from 'react';
 interface ProductProp {
-  // datas: any;
-  // path: string;
+  datas: any;
+  pathName: string;
   setPrice: React.Dispatch<React.SetStateAction<any>>;
-  // setEditTitle: React.Dispatch<React.SetStateAction<string>>;
+  setEditPrice: React.Dispatch<React.SetStateAction<any>>;
 }
 
-export default function PriceInput({ setPrice }: ProductProp) {
+export default function PriceInput({
+  datas,
+  pathName,
+  setPrice,
+  setEditPrice,
+}: ProductProp) {
   const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPrice(parseInt(e.target.value));
+    if (pathName === 'post') {
+      setPrice(parseInt(e.target.value));
+    } else {
+      setEditPrice(parseInt(e.target.value));
+    }
   };
+  useEffect(() => {
+    if (datas?.itemPrice !== undefined) {
+      setEditPrice(datas?.itemPrice);
+    }
+  }, [datas]);
   return (
-    <div className="flex items-center mt-8">
-      <label htmlFor="productTitle" className="w-20 text-label-gray">
-        금액
-      </label>
-      <input
-        id="productTitle"
-        type="text"
-        placeholder="숫자만 입력해 주세요 (원 단위)"
-        onChange={onChangeHandler}
-        className="w-full px-5 py-3 border rounded-3xl border-gray"
-      />
-    </div>
+    <>
+      {pathName === 'post' ? (
+        <div className="flex items-center mt-8">
+          <label htmlFor="productTitle" className="w-20 text-label-gray">
+            금액
+          </label>
+          <input
+            id="productTitle"
+            type="text"
+            placeholder="숫자만 입력해 주세요 (원 단위)"
+            onChange={onChangeHandler}
+            className="w-full px-5 py-3 border rounded-3xl border-gray"
+          />
+        </div>
+      ) : (
+        <div className="flex items-center mt-8">
+          <label htmlFor="productTitle" className="w-20 text-label-gray">
+            금액
+          </label>
+          <input
+            id="productTitle"
+            type="text"
+            placeholder="숫자만 입력해 주세요 (원 단위)"
+            onChange={onChangeHandler}
+            defaultValue={datas.itemPrice}
+            className="w-full px-5 py-3 border rounded-3xl border-gray"
+          />
+        </div>
+      )}
+    </>
   );
 }

--- a/FE/src/Components/LSM/Product/ProductForm/ProductForm.tsx
+++ b/FE/src/Components/LSM/Product/ProductForm/ProductForm.tsx
@@ -9,21 +9,42 @@ import TitleInput from './TitleInput';
 import PriceInput from './PriceInput';
 import CategoryInput from './CategoryInput';
 import api from 'api';
+import { useSelector } from 'react-redux';
+import type { StoreType } from 'model/redux';
 
-export default function ProductForm() {
+interface ProductEditProp {
+  datas: any;
+  pathName: string;
+}
+
+export default function ProductForm({ datas, pathName }: ProductEditProp) {
   const navigate = useNavigate();
+  const getItemId = useSelector((e: StoreType) => e.currentItemId);
 
   const [title, setTitle] = useState('');
   const [category, setCategory] = useState('');
-  const [price, setPrice] = useState<any>('');
-  const [imagePreview, setImagePreview] = useState<any>([]);
+  const [price, setPrice] = useState(0);
   const [images, setImages] = useState([]);
-  const [deliveryPrice, setDeliveryPrice] = useState<any>(0);
+  const [imagePreview, setImagePreview] = useState<any>([]);
+  const [deliveryPrice, setDeliveryPrice] = useState(0);
   const [options, setOptions] = useState([
     { optionName: '', itemCount: 0, optionDetail: '', additionalPrice: 0 },
   ]);
   const [defaultCount, setDefaultCount] = useState(0);
   const [contents, setContents] = useState('');
+
+  const [editTitle, setEditTitle] = useState(datas?.name);
+  const [editCategory, setEditCategory] = useState(datas?.category);
+  const [editPrice, setEditPrice] = useState(datas?.itemPrice);
+  const [editImages, setEditImages] = useState(datas?.infoList);
+  const [editDeliveryPrice, setEditDeliveryPrice] = useState(
+    datas?.deliveryPrice
+  );
+  const [editOptions, setEditOptions] = useState(datas?.optionList);
+  const [deleteOptions, setDeleteOptions] = useState<any>([]);
+  const [editContents, setEditContents] = useState(datas?.description);
+
+  console.log(datas);
 
   const postData = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -58,7 +79,6 @@ export default function ProductForm() {
         .post('/api/items', formData, {
           headers: {
             'Content-Type': 'multipart/form-data',
-            Authorization: localStorage.getItem('authorization'),
           },
         })
         .then((res) => {
@@ -68,15 +88,69 @@ export default function ProductForm() {
     } catch (error) {
       console.log(error);
     }
-    console.log(imagePreview, postDatas);
+    console.log(postDatas);
+  };
+
+  const patchData = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      const formData = new FormData();
+
+      formData.append('imageList', imagePreview);
+
+      const patchDatas = {
+        name: editTitle,
+        category: editCategory,
+        itemPrice: editPrice,
+        deliveryPrice: editDeliveryPrice,
+        description: editContents,
+        defaultCount,
+        discountRate: 0,
+        deleteImageId: null,
+        deleteOptionId: deleteOptions,
+        updateOptionList: [...editOptions],
+      };
+
+      formData.append(
+        'patch',
+        new Blob([JSON.stringify(patchDatas)], { type: 'application/json' })
+      );
+      console.log(patchDatas);
+      const res = await api.patch(`/api/items/${getItemId}`, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+      console.log(res);
+      navigate('/admin/productlist');
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   return (
     <form className="w-full">
       <div className="w-175">
-        <TitleInput setTitle={setTitle} />
-        <CategoryInput category={category} setCategory={setCategory} />
-        <PriceInput setPrice={setPrice} />
+        <TitleInput
+          datas={datas}
+          pathName={pathName}
+          setTitle={setTitle}
+          setEditTitle={setEditTitle}
+        />
+        <CategoryInput
+          datas={datas}
+          pathName={pathName}
+          setCategory={setCategory}
+          editCategory={editCategory}
+          setEditCategory={setEditCategory}
+        />
+        <PriceInput
+          datas={datas}
+          pathName={pathName}
+          setPrice={setPrice}
+          setEditPrice={setEditPrice}
+        />
       </div>
       <div className="w-200">
         <ImageInput
@@ -84,20 +158,37 @@ export default function ProductForm() {
           setImagePreview={setImagePreview}
           images={images}
           setImages={setImages}
+          editImages={editImages}
+          setEditImages={setEditImages}
         />
         <OrderInput
+          datas={datas}
+          pathName={pathName}
           deliveryPrice={deliveryPrice}
           setDeliveryPrice={setDeliveryPrice}
+          setEditDeliveryPrice={setEditDeliveryPrice}
         />
         <OptionInput
+          datas={datas}
+          pathName={pathName}
           options={options}
           setOptions={setOptions}
           setDefaultCount={setDefaultCount}
+          editOptions={editOptions}
+          setEditOptions={setEditOptions}
+          deleteOptions={deleteOptions}
+          setDeleteOptions={setDeleteOptions}
         />
       </div>
-      <ContentsInput contents={contents} setContents={setContents} />
-      {/* <Button postData={postData} patchData={patchData} /> */}
-      <Button postData={postData} />
+      <ContentsInput
+        datas={datas}
+        pathName={pathName}
+        contents={contents}
+        setContents={setContents}
+        editContents={editContents}
+        setEditContents={setEditContents}
+      />
+      <Button postData={postData} patchData={patchData} />
     </form>
   );
 }

--- a/FE/src/Components/LSM/Product/ProductForm/Select.tsx
+++ b/FE/src/Components/LSM/Product/ProductForm/Select.tsx
@@ -1,84 +1,63 @@
-// import { useEffect } from 'react';
 interface CategoryInputProp {
-  // datas: any;
-  // path: string;
-  category: string;
+  pathName: string;
   setCategory: React.Dispatch<React.SetStateAction<string>>;
-  // setEditCategory: React.Dispatch<React.SetStateAction<string>>;
-  // editCategory: string;
-  // id: string;
+  setEditCategory: React.Dispatch<React.SetStateAction<string>>;
+  editCategory: string;
 }
 
-export default function Select({ setCategory }: CategoryInputProp) {
+export default function Select({
+  pathName,
+  setCategory,
+  setEditCategory,
+  editCategory,
+}: CategoryInputProp) {
   const selectHandler = (e: any) => {
-    setCategory(e.target.value);
+    if (pathName === 'post') {
+      setCategory(e.target.value);
+    } else {
+      setEditCategory(e.target.value);
+    }
   };
-  // const selectHandler = (e: any) => {
-  //   if (path === 'post') {
-  //     setCategory(e.target.value);
-  //   } else {
-  //     setEditCategory(e.target.value);
-  //   }
-  // };
-
-  // useEffect(() => {
-  //   setEditCategory(datas?.category);
-  // }, [datas?.category]);
 
   return (
     <>
-      <div className="w-full">
-        <select
-          name="notice"
-          className="w-full px-4 py-3 border rounded-3xl border-gray"
-          defaultValue={'none'}
-          onChange={selectHandler}
-          required={true}
-        >
-          <option value="none">카테고리를 선택해주세요</option>
-          <option value="COMPUTER">컴퓨터</option>
-          <option value="MONITOR">모니터</option>
-          <option value="MOUSE">마우스</option>
-          <option value="HEADSET">헤드셋</option>
-          <option value="CHAIR">의자</option>
-          <option value="DESK">책상</option>
-        </select>
-      </div>
-      {/* {path === 'post' ? (
-        <div className="">
+      {pathName === 'post' ? (
+        <div className="w-full">
           <select
             name="notice"
-            className="px-2 py-1.5 border rounded-lg border-gray"
+            className="w-full px-4 py-3 border rounded-3xl border-gray"
             defaultValue={'none'}
             onChange={selectHandler}
             required={true}
           >
-            <option value="none" disabled>
-              카테고리 선택
-            </option>
-            <option value="OPERATING">운영정책</option>
-            <option value="UPDATE">업데이트</option>
-            <option value="EVENT">이벤트</option>
+            <option value="none">카테고리를 선택해주세요</option>
+            <option value="COMPUTER">컴퓨터</option>
+            <option value="MONITOR">모니터</option>
+            <option value="MOUSE">마우스</option>
+            <option value="HEADSET">헤드셋</option>
+            <option value="CHAIR">의자</option>
+            <option value="DESK">책상</option>
           </select>
         </div>
       ) : (
-        <div className="">
+        <div className="w-full">
           <select
             name="notice"
-            className="px-2 py-1.5 border rounded-lg border-gray"
+            className="w-full px-4 py-3 border rounded-3xl border-gray"
             value={editCategory}
             onChange={selectHandler}
             required={true}
           >
-            <option value="none" disabled>
-              카테고리 선택
-            </option>
-            <option value="OPERATING">운영정책</option>
-            <option value="UPDATE">업데이트</option>
-            <option value="EVENT">이벤트</option>
+            <option value="none">카테고리를 선택해주세요</option>
+            <option value="COMPUTER">컴퓨터</option>
+            <option value="MONITOR">모니터</option>
+            <option value="MOUSE">마우스</option>
+            <option value="HEADSET">헤드셋</option>
+            <option value="CHAIR">의자</option>
+            <option value="DESK">책상</option>
           </select>
         </div>
-      )} */}
+      )}
     </>
   );
 }

--- a/FE/src/Components/LSM/Product/ProductForm/TitleInput.tsx
+++ b/FE/src/Components/LSM/Product/ProductForm/TitleInput.tsx
@@ -1,25 +1,58 @@
+import { useEffect } from 'react';
 interface ProductProp {
-  // datas: any;
-  // path: string;
+  datas: any;
+  pathName: string;
   setTitle: React.Dispatch<React.SetStateAction<string>>;
-  // setEditTitle: React.Dispatch<React.SetStateAction<string>>;
+  setEditTitle: React.Dispatch<React.SetStateAction<string>>;
 }
-export default function TitleInput({ setTitle }: ProductProp) {
+export default function TitleInput({
+  datas,
+  pathName,
+  setTitle,
+  setEditTitle,
+}: ProductProp) {
   const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTitle(e.target.value);
+    if (pathName === 'post') {
+      setTitle(e.target.value);
+    } else {
+      setEditTitle(e.target.value);
+    }
   };
+  useEffect(() => {
+    if (datas?.name !== undefined) {
+      setEditTitle(datas?.name);
+    }
+  }, [datas]);
   return (
-    <div className="flex items-center">
-      <label htmlFor="productTitle" className="w-20 text-label-gray">
-        상품명
-      </label>
-      <input
-        id="productTitle"
-        type="text"
-        placeholder="상품명을 입력해 주세요"
-        onChange={onChangeHandler}
-        className="w-full px-5 py-3 border rounded-3xl border-gray"
-      />
-    </div>
+    <>
+      {pathName === 'post' ? (
+        <div className="flex items-center">
+          <label htmlFor="productTitle" className="w-20 text-label-gray">
+            상품명
+          </label>
+          <input
+            id="productTitle"
+            type="text"
+            placeholder="상품명을 입력해 주세요"
+            onChange={onChangeHandler}
+            className="w-full px-5 py-3 border rounded-3xl border-gray"
+          />
+        </div>
+      ) : (
+        <div className="flex items-center">
+          <label htmlFor="productTitle" className="w-20 text-label-gray">
+            상품명
+          </label>
+          <input
+            id="productTitle"
+            type="text"
+            placeholder="상품명을 입력해 주세요"
+            onChange={onChangeHandler}
+            defaultValue={datas.name}
+            className="w-full px-5 py-3 border rounded-3xl border-gray"
+          />
+        </div>
+      )}
+    </>
   );
 }

--- a/FE/src/Components/LSM/Product/ProductTitle.tsx
+++ b/FE/src/Components/LSM/Product/ProductTitle.tsx
@@ -2,11 +2,13 @@ import { useLocation } from 'react-router-dom';
 
 export default function ProductTitle() {
   const path: string = useLocation().pathname.slice(19);
+  const adminPath: string = useLocation().pathname.split('/').slice(3)[0];
 
   const pathList = ['post', 'edit'];
   const titleList = ['상품등록', '상품수정'];
 
-  const idx = pathList.indexOf(path);
+  const idx =
+    path === 'post' ? pathList.indexOf(path) : pathList.indexOf(adminPath);
   const title = titleList[idx];
 
   return (

--- a/FE/src/Pages/LSM/Main.tsx
+++ b/FE/src/Pages/LSM/Main.tsx
@@ -16,7 +16,7 @@ export default function Main() {
   const fetchData = async () => {
     try {
       const bestItemRes = await api.get(
-        '/api/items?page=0&size=10&sort=createdAt'
+        '/api/items?page=0&size=10&sort=salesQuantity'
       );
       setBestItemsData(bestItemRes?.data?.data?.content);
 

--- a/FE/src/Pages/LSM/Product/ProductEdit.tsx
+++ b/FE/src/Pages/LSM/Product/ProductEdit.tsx
@@ -1,11 +1,41 @@
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import type { StoreType } from 'model/redux';
 import ProductForm from 'Components/LSM/Product/ProductForm/ProductForm';
 import ProductTitle from 'Components/LSM/Product/ProductTitle';
+import api from 'api';
+import { setOptionId } from 'store/modules/setOptionId';
 
 export default function ProductEdit() {
+  const pathName = useLocation().pathname.split('/').slice(3)[0];
+  const [datas, setDatas] = useState({});
+  const getItemId = useSelector((e: StoreType) => e.currentItemId);
+  const dispatch = useDispatch();
+
+  const fetchData = async () => {
+    try {
+      const res = await api.get(`/api/items/${getItemId}`);
+      setDatas(res?.data?.data);
+      const optionList = res?.data?.data?.optionList;
+      dispatch(setOptionId(optionList));
+
+      // optionList.forEach((option: any) => {
+      //   dispatch(setOptionId(option.optionId));
+      // });
+      console.log(res?.data?.data);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  useEffect(() => {
+    void fetchData();
+  }, []);
+
   return (
     <div className="pr-16 mb-16">
       <ProductTitle />
-      <ProductForm />
+      {pathName === 'edit' && <ProductForm datas={datas} pathName={pathName} />}
     </div>
   );
 }

--- a/FE/src/Pages/LSM/Product/ProductPost.tsx
+++ b/FE/src/Pages/LSM/Product/ProductPost.tsx
@@ -1,11 +1,14 @@
+import { useLocation } from 'react-router-dom';
 import ProductForm from 'Components/LSM/Product/ProductForm/ProductForm';
 import ProductTitle from 'Components/LSM/Product/ProductTitle';
 
 export default function ProductPost() {
+  const pathName = useLocation().pathname.split('/').slice(3)[0];
+
   return (
     <div className="pr-16 mb-16">
       <ProductTitle />
-      <ProductForm />
+      {pathName === 'post' && <ProductForm datas={null} pathName={pathName} />}
     </div>
   );
 }

--- a/FE/src/model/redux.ts
+++ b/FE/src/model/redux.ts
@@ -2,4 +2,5 @@ export interface StoreType {
   currentAddress: number;
   currentItemId: number;
   currentTab: number;
+  currentOptionId: number;
 }

--- a/FE/src/store/modules/setOptionId.ts
+++ b/FE/src/store/modules/setOptionId.ts
@@ -1,0 +1,20 @@
+export const SET_OPTIONID = 'contents/SET_OPTIONID';
+
+export const setOptionId = (optionId: number) => ({
+  type: SET_OPTIONID,
+  payload: optionId,
+});
+
+const initialState = 0;
+
+export default function currentOptionId(
+  state = initialState,
+  action: ReturnType<typeof setOptionId>
+) {
+  switch (action.type) {
+    case SET_OPTIONID:
+      return action.payload;
+    default:
+      return state;
+  }
+}

--- a/FE/src/store/store.ts
+++ b/FE/src/store/store.ts
@@ -2,11 +2,13 @@ import { combineReducers, legacy_createStore as createStore } from 'redux';
 import currentAddress from './modules/setCurrentIndex';
 import currentItemId from './modules/setItemId';
 import currentTab from './modules/setCurrentTab';
+import currentOptionId from './modules/setOptionId';
 
 const reducers = combineReducers({
   currentAddress,
   currentItemId,
   currentTab,
+  currentOptionId,
 });
 
 const store = createStore(reducers);


### PR DESCRIPTION
### 변경사항
- 메인페이지 정렬 id 값 UI 재설정
- 메인페이지 best-item 정렬 재배치
- 메인페이지 이미지API 삭제 후 고정이미지 설정
- 상품 수정 페이지 상품명 인풋 구현
- 상품 수정 페이지 submit 버튼 POST/PATCH 요청 분기설정
- 상품 수정 페이지 카테고리 셀렉터 구현
- 상품 수정 페이지 에디터 구현
- 상품 수정 페이지 이미지 인풋 구현
- 상품 수정 페이지 옵션 다중인풋 구현
- 상품 수정 페이지 상품가격 인풋 구현
- 상품 수정 페이지 배송비 인풋 구현
- 상품 수정 페이지 카테고리 인풋 POST/PATCH 분기 설정
- 상품 수정 폼 기능 구현
- 상품 수정 페이지 GET 요청 후 기존 데이터 로드
- 상품 등록 페이지 분기별 ProductForm 설정
- 상품 수정 페이지 라우터 재설정
- 상품 수정 페이지 optionId 리덕스 설정

