### PR TITLE
Item 도메인 구현 완료

### DIFF
--- a/BE/backend/build.gradle
+++ b/BE/backend/build.gradle
@@ -60,10 +60,13 @@ dependencies {
 	implementation 'com.google.guava:guava:31.1-jre'
 	//스웨거
 	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
-//	implementation('org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4')
 
 	//아임포트
 	implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
+	//Spring Test Container
+	testImplementation 'org.testcontainers:testcontainers'
+	testImplementation "org.testcontainers:junit-jupiter:1.19.0"
+	testImplementation "org.testcontainers:mysql:1.19.0"
 }
 
 tasks.named('test') {

--- a/BE/backend/src/main/java/project/main/webstore/domain/DefaultMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/DefaultMapper.java
@@ -1,0 +1,14 @@
+package project.main.webstore.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface DefaultMapper {
+    default List<Long> checkListEmpty(List<Long> list) {
+        if (list == null) {
+            return new ArrayList<>();
+        }
+        return list;
+    }
+
+}

--- a/BE/backend/src/main/java/project/main/webstore/domain/DefaultMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/DefaultMapper.java
@@ -2,13 +2,27 @@ package project.main.webstore.domain;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import project.main.webstore.dto.CustomPage;
+import project.main.webstore.dto.Dto;
+import project.main.webstore.dto.PageInfo;
 
 public interface DefaultMapper {
+
     default List<Long> checkListEmpty(List<Long> list) {
         if (list == null) {
             return new ArrayList<>();
         }
         return list;
+    }
+
+    default CustomPage transCustomPage(Page<? extends Dto> pageDate) {
+        return new CustomPage<>(pageDate.getContent(),
+                new PageInfo(pageDate.getPageable().getOffset(), pageDate.getSize(),
+                        pageDate.getTotalElements(), pageDate.isFirst(),
+                        pageDate.getNumberOfElements(), pageDate.isFirst(),
+                        pageDate.getTotalPages()));
+
     }
 
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/image/mapper/ImageMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/image/mapper/ImageMapper.java
@@ -1,18 +1,21 @@
 package project.main.webstore.domain.image.mapper;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import project.main.webstore.domain.image.dto.ImageDto;
 import project.main.webstore.domain.image.dto.ImageInfoDto;
 import project.main.webstore.domain.image.dto.ImageSortDto;
+import project.main.webstore.domain.image.entity.Image;
 import project.main.webstore.exception.BusinessLogicException;
 import project.main.webstore.exception.CommonExceptionCode;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
 public class ImageMapper {
-    public ImageInfoDto toLocalDto(MultipartFile file, ImageSortDto sortDto, String uploadDir){
+
+    public ImageInfoDto toLocalDto(MultipartFile file, ImageSortDto sortDto, String uploadDir) {
         return ImageInfoDto.dtoBuilder()
                 .multipartFile(file)
                 .order(sortDto.getOrderNumber())
@@ -23,18 +26,21 @@ public class ImageMapper {
     }
 
     public ImageInfoDto toLocalDto(ImageSortDto sortDto) {
-        return new ImageInfoDto(sortDto.findImageId(), sortDto.getOrderNumber(), sortDto.isRepresentative());
+        return new ImageInfoDto(sortDto.findImageId(), sortDto.getOrderNumber(),
+                sortDto.isRepresentative());
     }
-    public List<ImageInfoDto> toLocalDtoList(List<MultipartFile>fileList, List<? extends ImageSortDto> imageSortDto, String uploadDir){
-        checkImageParam(fileList,imageSortDto);
+
+    public List<ImageInfoDto> toLocalDtoList(List<MultipartFile> fileList,
+            List<? extends ImageSortDto> imageSortDto, String uploadDir) {
+        checkImageParam(fileList, imageSortDto);
         List<ImageInfoDto> result = new ArrayList<>();
         int j = 0;
-        for(int i = 0 ; i < imageSortDto.size(); i++){
+        for (int i = 0; i < imageSortDto.size(); i++) {
             ImageInfoDto infoDto;
-            if(imageSortDto.get(i).findImageId() == null){
+            if (imageSortDto.get(i).findImageId() == null) {
                 infoDto = toLocalDto(fileList.get(j++), imageSortDto.get(i), uploadDir);
 
-            }else{
+            } else {
                 infoDto = toLocalDto(imageSortDto.get(i));
             }
 
@@ -52,12 +58,18 @@ public class ImageMapper {
                 .uploadDir(uploadDir)
                 .build();
     }
-    private void checkImageParam(List<MultipartFile> imageList, List<? extends ImageSortDto> infoList) {
-        if(imageList == null && infoList != null){
+
+    private void checkImageParam(List<MultipartFile> imageList,
+            List<? extends ImageSortDto> infoList) {
+        if (imageList == null && infoList != null) {
             throw new BusinessLogicException(CommonExceptionCode.IMAGE_NOT_POST);
         }
         if (imageList != null && infoList == null) {
             throw new BusinessLogicException(CommonExceptionCode.IMAGE_INFO_NOT_POST);
         }
+    }
+
+    public List<ImageDto> toImageResponseDtoList(List<? extends Image> imageList) {
+        return imageList.stream().map(ImageDto::new).collect(Collectors.toList());
     }
 }

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/controller/ItemController.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/controller/ItemController.java
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import project.main.webstore.domain.image.dto.ImageInfoDto;
-import project.main.webstore.domain.image.mapper.ImageMapper;
 import project.main.webstore.domain.item.dto.ItemIdResponseDto;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
@@ -54,9 +53,8 @@ import project.main.webstore.utils.UriCreator;
 public class ItemController {
     private static final String ITEM_DEFAULT_URL = "items";
     private static final String UPLOAD_DIR = "item";
-    private final ItemService itemService;
-    private final ItemMapper itemMapper;
-    private final ImageMapper imageMapper;
+    private final ItemService service;
+    private final ItemMapper mapper;
 
     //상품과 스펙, 옵션을 모두 등록
     @PostMapping(
@@ -67,15 +65,15 @@ public class ItemController {
                                                                      @Parameter(description = "Image files", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
                                                                              array = @ArraySchema(schema = @Schema(type = "string", format = "binary"))), style = ParameterStyle.FORM, explode = Explode.TRUE)
                                                                      @RequestPart(required = false) List<MultipartFile> imageList) {
-        Item request = itemMapper.toEntity(post);
+        Item request = mapper.toEntity(post);
         Item result;
         if (imageList != null) {
-            List<ImageInfoDto> imageInfoList = imageMapper.toLocalDtoList(imageList, post.getInfoList(), UPLOAD_DIR);
-            result = itemService.postItem(request, imageInfoList);
+            List<ImageInfoDto> imageInfoList = mapper.toLocalDtoList(imageList, post.getInfoList(), UPLOAD_DIR);
+            result = service.postItem(request, imageInfoList);
         } else {
-            result = itemService.postItem(request);
+            result = service.postItem(request);
         }
-        ItemIdResponseDto response = itemMapper.toIdResponse(result);
+        ItemIdResponseDto response = mapper.toIdResponse(result);
         URI location = UriCreator.createUri(ITEM_DEFAULT_URL, result.getItemId());
         var responseDto = ResponseDto.<ItemIdResponseDto>builder().data(response).customCode(ResponseCode.CREATED).build();
 
@@ -92,32 +90,32 @@ public class ItemController {
                                                                     @RequestPart(required = false) ItemPatchDto patch,
                                                                     @RequestPart(required = false) List<MultipartFile> imageList) {
 
-        Item request = itemMapper.itemPatchDtoToItem(patch,itemId);
-        List<Long> requestDeleteOptionIdList = itemMapper.checkListEmpty(patch.getDeleteOptionId());
-        List<Long> requestDeleteImageList = itemMapper.checkListEmpty(patch.getDeleteImageId());
+        Item request = mapper.itemPatchDtoToItem(patch,itemId);
+        List<Long> requestDeleteOptionIdList = mapper.checkListEmpty(patch.getDeleteOptionId());
+        List<Long> requestDeleteImageList = mapper.checkListEmpty(patch.getDeleteImageId());
 
         List<ImageInfoDto> imageInfoDtoList = null;
 
         if (patch.getImageSortAndRepresentativeInfo() != null) {
-            imageInfoDtoList = imageMapper.toLocalDtoList(imageList, patch.getImageSortAndRepresentativeInfo(), UPLOAD_DIR);
+            imageInfoDtoList = mapper.toLocalDtoList(imageList, patch.getImageSortAndRepresentativeInfo(), UPLOAD_DIR);
         }
 
-        Item result = itemService.patchItem(imageInfoDtoList, requestDeleteImageList, request,requestDeleteOptionIdList);
+        Item result = service.patchItem(imageInfoDtoList, requestDeleteImageList, request,requestDeleteOptionIdList);
 
-        ItemIdResponseDto response = itemMapper.toIdResponse(result);
+        ItemIdResponseDto response = mapper.toIdResponse(result);
         URI uri = UriCreator.createUri(ITEM_DEFAULT_URL, result.getItemId());
         var responseDto = ResponseDto.<ItemIdResponseDto>builder().data(response).customCode(ResponseCode.OK).build();
 
         return ResponseEntity.ok().header("Location", uri.toString()).body(responseDto);
     }
 
-    @DeleteMapping("/{item-Id}")
-    @ApiResponse(responseCode = "204", description = "상품 삭제 성공")
-    public ResponseEntity deleteItem(@PathVariable("item-Id") @Positive Long itemId) {
-        itemService.deleteItem(itemId);
-        URI location = UriCreator.createUri(ITEM_DEFAULT_URL);
-        return ResponseEntity.noContent().header("Location", location.toString()).build();
-    }
+        @DeleteMapping("/{item-Id}")
+        @ApiResponse(responseCode = "204", description = "상품 삭제 성공")
+        public ResponseEntity deleteItem(@PathVariable("item-Id") @Positive Long itemId) {
+            service.deleteItem(itemId);
+            URI location = UriCreator.createUri(ITEM_DEFAULT_URL);
+            return ResponseEntity.noContent().header("Location", location.toString()).build();
+        }
 
     // 단일 아이템 조회
     @GetMapping("/{item-Id}")
@@ -125,8 +123,8 @@ public class ItemController {
     public ResponseEntity<ResponseDto<ItemResponseDto>> getItem(@PathVariable("item-Id") @Positive Long itemId,
                                                                 @Parameter(hidden = true) @AuthenticationPrincipal Object principal) {
         Long userId = CheckLoginUser.getContextIdx(principal);
-        Item item = itemService.getItem(itemId, userId);
-        ItemResponseDto response = itemMapper.toGetResponseDto(item);
+        Item item = service.getItem(itemId, userId);
+        ItemResponseDto response = mapper.toGetResponseDto(item);
         var responseDto = ResponseDto.<ItemResponseDto>builder().data(response).customCode(ResponseCode.OK).build();
         return ResponseEntity.ok(responseDto);
     }
@@ -142,8 +140,8 @@ public class ItemController {
                                                                          @Parameter(hidden = true) @PageableDefault Pageable pageable,
                                                                          @Parameter(hidden = true) @AuthenticationPrincipal Object principal) {
         Long userId = CheckLoginUser.getContextIdx(principal);
-        Page<Item> result = itemService.searchItem(itemName, pageable, userId);
-        Page<ItemResponseDto> response = itemMapper.toGetPageResponse(result);
+        Page<Item> result = service.searchItem(itemName, pageable, userId);
+        Page<ItemResponseDto> response = mapper.toGetPageResponse(result);
         var responseDto = ResponseDto.<Page<ItemResponseDto>>builder().data(response).customCode(ResponseCode.OK).build();
 
         return ResponseEntity.ok(responseDto);
@@ -161,8 +159,8 @@ public class ItemController {
                                                                                 @Parameter(hidden = true) @PageableDefault(sort = "itemId") Pageable pageable,
                                                                                 @Parameter(hidden = true) @AuthenticationPrincipal Object principal) {
         Long userId = CheckLoginUser.getContextIdx(principal);
-        Page<Item> result = itemService.findItemByCategory(category, pageable, userId);
-        Page<ItemResponseDto> response = itemMapper.toGetPageResponse(result);
+        Page<Item> result = service.findItemByCategory(category, pageable, userId);
+        Page<ItemResponseDto> response = mapper.toGetPageResponse(result);
         var responseDto = ResponseDto.<Page<ItemResponseDto>>builder().data(response).customCode(ResponseCode.OK).build();
 
         return ResponseEntity.ok(responseDto);
@@ -179,8 +177,8 @@ public class ItemController {
     public ResponseEntity<ResponseDto<Page<ItemResponseDto>>> getItemAllByPage(@Parameter(hidden = true) @PageableDefault(sort = "itemId") Pageable pageable,
                                                                                  @Parameter(hidden = true) @AuthenticationPrincipal Object principal) {
         Long userId = CheckLoginUser.getContextIdx(principal);
-        Page<Item> result = itemService.findItemPage(pageable, userId);
-        Page<ItemResponseDto> response = itemMapper.toGetPageResponse(result);
+        Page<Item> result = service.findItemPage(pageable, userId);
+        Page<ItemResponseDto> response = mapper.toGetPageResponse(result);
         var responseDto = ResponseDto.<Page<ItemResponseDto>>builder().data(response).customCode(ResponseCode.OK).build();
 
         return ResponseEntity.ok(responseDto);
@@ -190,8 +188,8 @@ public class ItemController {
     @ApiResponse(responseCode = "200", description = "상품 좋아요 기능")
     public ResponseEntity<ResponseDto<List<ItemResponseDto>>> pickItem(@Parameter(hidden = true) @AuthenticationPrincipal Object principal) {
         Long userId = CheckLoginUser.getContextIdx(principal);
-        List<Item> result = itemService.getPickedItem(userId);
-        List<ItemResponseDto> response = itemMapper.toGetResponseListDto(result);
+        List<Item> result = service.getPickedItem(userId);
+        List<ItemResponseDto> response = mapper.toGetResponseListDto(result);
         var responseDto = ResponseDto.<List<ItemResponseDto>>builder().data(response).customCode(ResponseCode.OK).build();
         return ResponseEntity.ok(responseDto);
     }
@@ -203,7 +201,7 @@ public class ItemController {
                                                                @RequestParam Long userId,
                                                                @Parameter(hidden = true) @AuthenticationPrincipal Object principal) {
         CheckLoginUser.validUserSame(principal, userId);
-        PickedItemDto result = itemService.pickItem(itemId, userId);
+        PickedItemDto result = service.pickItem(itemId, userId);
 
         var responseDto = ResponseDto.<PickedItemDto>builder().data(result).customCode(ResponseCode.OK).build();
         return ResponseEntity.ok(responseDto);

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/controller/ItemController.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/controller/ItemController.java
@@ -40,6 +40,7 @@ import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.item.enums.Category;
 import project.main.webstore.domain.item.mapper.ItemMapper;
 import project.main.webstore.domain.item.service.ItemService;
+import project.main.webstore.dto.CustomPage;
 import project.main.webstore.dto.ResponseDto;
 import project.main.webstore.enums.ResponseCode;
 import project.main.webstore.utils.CheckLoginUser;
@@ -136,13 +137,13 @@ public class ItemController {
             @Parameter(name = "size", example = "20", description = "한번에 전달될 데이터 크기, 사이즈 기본 값 존재 생략 가능"),
             @Parameter(name = "sort", example = "createdAt", description = "정렬할 기준이 되는 필드, 기본 값이 createdAt으로 설정되어있다. 생략 가능")
     })
-    public ResponseEntity<ResponseDto<Page<ItemResponseDto>>> searchItem(@RequestParam String itemName,
+    public ResponseEntity<ResponseDto<CustomPage<ItemResponseDto>>> searchItem(@RequestParam String itemName,
                                                                          @Parameter(hidden = true) @PageableDefault Pageable pageable,
                                                                          @Parameter(hidden = true) @AuthenticationPrincipal Object principal) {
         Long userId = CheckLoginUser.getContextIdx(principal);
         Page<Item> result = service.searchItem(itemName, pageable, userId);
-        Page<ItemResponseDto> response = mapper.toGetPageResponse(result);
-        var responseDto = ResponseDto.<Page<ItemResponseDto>>builder().data(response).customCode(ResponseCode.OK).build();
+        CustomPage<ItemResponseDto> response = mapper.toGetPageResponse(result);
+        var responseDto = ResponseDto.<CustomPage<ItemResponseDto>>builder().data(response).customCode(ResponseCode.OK).build();
 
         return ResponseEntity.ok(responseDto);
     }
@@ -155,13 +156,13 @@ public class ItemController {
             @Parameter(name = "size", example = "20", description = "한번에 전달될 데이터 크기, 사이즈 기본 값 존재 생략 가능"),
             @Parameter(name = "sort", example = "createdAt", description = "정렬할 기준이 되는 필드, 기본 값이 createdAt으로 설정되어있다. 생략 가능")
     })
-    public ResponseEntity<ResponseDto<Page<ItemResponseDto>>> getItemByCategory(@RequestParam Category category,
+    public ResponseEntity<ResponseDto<CustomPage<ItemResponseDto>>> getItemByCategory(@RequestParam Category category,
                                                                                 @Parameter(hidden = true) @PageableDefault(sort = "itemId") Pageable pageable,
                                                                                 @Parameter(hidden = true) @AuthenticationPrincipal Object principal) {
         Long userId = CheckLoginUser.getContextIdx(principal);
         Page<Item> result = service.findItemByCategory(category, pageable, userId);
-        Page<ItemResponseDto> response = mapper.toGetPageResponse(result);
-        var responseDto = ResponseDto.<Page<ItemResponseDto>>builder().data(response).customCode(ResponseCode.OK).build();
+        CustomPage<ItemResponseDto> response = mapper.toGetPageResponse(result);
+        var responseDto = ResponseDto.<CustomPage<ItemResponseDto>>builder().data(response).customCode(ResponseCode.OK).build();
 
         return ResponseEntity.ok(responseDto);
     }
@@ -174,12 +175,12 @@ public class ItemController {
             @Parameter(name = "size", example = "20", description = "한번에 전달될 데이터 크기, 사이즈 기본 값 존재 생략 가능"),
             @Parameter(name = "sort", example = "createdAt", description = "정렬할 기준이 되는 필드, 기본 값이 itemId 으로 설정되어있다. 생략 가능")
     })
-    public ResponseEntity<ResponseDto<Page<ItemResponseDto>>> getItemAllByPage(@Parameter(hidden = true) @PageableDefault(sort = "itemId") Pageable pageable,
+    public ResponseEntity<ResponseDto<CustomPage<ItemResponseDto>>> getItemAllByPage(@Parameter(hidden = true) @PageableDefault(sort = "itemId") Pageable pageable,
                                                                                  @Parameter(hidden = true) @AuthenticationPrincipal Object principal) {
         Long userId = CheckLoginUser.getContextIdx(principal);
         Page<Item> result = service.findItemPage(pageable, userId);
-        Page<ItemResponseDto> response = mapper.toGetPageResponse(result);
-        var responseDto = ResponseDto.<Page<ItemResponseDto>>builder().data(response).customCode(ResponseCode.OK).build();
+        CustomPage<ItemResponseDto> response = mapper.toGetPageResponse(result);
+        var responseDto = ResponseDto.<CustomPage<ItemResponseDto>>builder().data(response).customCode(ResponseCode.OK).build();
 
         return ResponseEntity.ok(responseDto);
     }

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/controller/ItemController.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/controller/ItemController.java
@@ -198,10 +198,10 @@ public class ItemController {
     @PostMapping("/{itemId}/favorite")
     @ApiResponse(responseCode = "200", description = "상품 좋아요 기능")
     public ResponseEntity<ResponseDto<PickedItemDto>> pickItem(@PathVariable @Positive Long itemId,
-                                                               @RequestParam Long userId,
+                                                               @RequestParam(required = false) Long userId,
                                                                @Parameter(hidden = true) @AuthenticationPrincipal Object principal) {
-        CheckLoginUser.validUserSame(principal, userId);
-        PickedItemDto result = service.pickItem(itemId, userId);
+        Long userIdx = CheckLoginUser.getContextIdx(principal);
+        PickedItemDto result = service.pickItem(itemId, userIdx);
 
         var responseDto = ResponseDto.<PickedItemDto>builder().data(result).customCode(ResponseCode.OK).build();
         return ResponseEntity.ok(responseDto);

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemPatchDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemPatchDto.java
@@ -1,6 +1,8 @@
 package project.main.webstore.domain.item.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import javax.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,15 +10,14 @@ import lombok.Setter;
 import project.main.webstore.domain.image.dto.ImageSortPatchDto;
 import project.main.webstore.domain.item.enums.Category;
 
-import javax.validation.constraints.Pattern;
-import java.util.List;
-
 @Getter
 @Setter
 @Schema(description = "상품 수정 스키마")
 @NoArgsConstructor
 @AllArgsConstructor
 public class ItemPatchDto {
+    @Schema(hidden = true)
+    private Long itemId;
     @Schema(example = "COMPUTER", allowableValues = {"COMPUTER", "MONITOR", "MOUSE", "HEADSET", "CHAIR", "DESK"})
     private Category category;
     @Schema(example = "맥북", description = "상품 이름")

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemPatchDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemPatchDto.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import javax.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,6 +13,7 @@ import project.main.webstore.domain.item.enums.Category;
 
 @Getter
 @Setter
+@Builder
 @Schema(description = "상품 수정 스키마")
 @NoArgsConstructor
 @AllArgsConstructor

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemResponseDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemResponseDto.java
@@ -12,13 +12,14 @@ import lombok.Setter;
 import project.main.webstore.domain.image.dto.ImageDto;
 import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.item.enums.Category;
+import project.main.webstore.dto.Dto;
 
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ItemResponseDto {
+public class ItemResponseDto implements Dto {
     @Schema(description = "아이템 식별자")
     private Long itemId;
     @Schema(example = "COMPUTER",allowableValues = {"COMPUTER", "MONITOR", "MOUSE", "HEADSET", "CHAIR", "DESK"})

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemResponseDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/dto/ItemResponseDto.java
@@ -1,6 +1,10 @@
 package project.main.webstore.domain.item.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,13 +13,11 @@ import project.main.webstore.domain.image.dto.ImageDto;
 import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.item.enums.Category;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class ItemResponseDto {
     @Schema(description = "아이템 식별자")
     private Long itemId;

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/dto/PickedItemDto.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/dto/PickedItemDto.java
@@ -1,10 +1,12 @@
 package project.main.webstore.domain.item.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
+@AllArgsConstructor
 public class PickedItemDto {
     private Long userId;
     private Long itemId;

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
@@ -1,6 +1,27 @@
 package project.main.webstore.domain.item.entity;
 
+import static javax.persistence.CascadeType.ALL;
+import static javax.persistence.EnumType.STRING;
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import javax.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,22 +36,15 @@ import project.main.webstore.domain.item.enums.ItemStatus;
 import project.main.webstore.domain.qna.entity.Question;
 import project.main.webstore.domain.review.entity.Review;
 
-import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static javax.persistence.CascadeType.ALL;
-import static javax.persistence.EnumType.STRING;
-import static javax.persistence.FetchType.LAZY;
-import static javax.persistence.GenerationType.IDENTITY;
-
 @Getter
 @Entity
+@Builder
 @Table(uniqueConstraints = {@UniqueConstraint(columnNames = "itemId")})
 @NoArgsConstructor
+@AllArgsConstructor
 public class Item extends Auditable {
     @Setter
+    @Default
     @OneToMany(mappedBy = "item", cascade = ALL, orphanRemoval = true)
     private List<ItemImage> itemImageList = new ArrayList<>();
     @Id
@@ -48,6 +62,7 @@ public class Item extends Auditable {
     private long viewCount;
 
     @Setter
+    @Default
     @Enumerated(STRING)
     private ItemStatus itemStatus = ItemStatus.ON_STACK;
 
@@ -69,14 +84,17 @@ public class Item extends Auditable {
     private boolean like;
 
     // 연관관계 매핑 //
+    @Default
     @OneToMany(mappedBy = "item", orphanRemoval = true, cascade = ALL)
     private List<ItemOption> optionList = new ArrayList<>();
-
+    @Default
     @OneToMany(mappedBy = "item", cascade = ALL, orphanRemoval = true)
     private List<Review> reviewList = new ArrayList<>();
+    @Default
     @OneToMany(mappedBy = "item", cascade = ALL, orphanRemoval = true)
     private List<Question> questionList = new ArrayList<>();
     //PickedItem 연관관계 매핑
+    @Default
     @OneToMany(fetch = LAZY, cascade = ALL, mappedBy = "item")
     private List<PickedItem> pickedItem = new ArrayList<>();
 
@@ -84,6 +102,7 @@ public class Item extends Auditable {
     @Setter
     private ItemOption defaultItem;
     @Setter
+    @Default
     @OneToMany(cascade = ALL,orphanRemoval = true)
     private List<CartItem> cartItemList = new ArrayList<>();
     public Item(Long itemId) {
@@ -116,7 +135,6 @@ public class Item extends Auditable {
 
 
 
-    @Builder(builderMethodName = "stub")
     public Item(List<ItemImage> itemImageList, Long itemId, String itemName, String description, Integer itemPrice, Integer deliveryPrice, Integer discountRate, Category category, List<ItemOption> optionList, List<CartItem> cartItemList, List<Review> reviewList, List<Question> questionList, List<PickedItem> pickedItem, ItemOption defaultItem) {
         this.itemId = itemId;
         this.itemName = itemName;

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
@@ -219,6 +219,16 @@ public class Item extends Auditable {
         }
         return optionList;
     }
+    public void addOptionList(List<ItemOption> itemOptionList) {
+        for (ItemOption itemOption : itemOptionList) {
+            this.optionList.add(itemOption);
+            itemOption.setItem(this);
+        }
+    }
+    public void addDefaultItem(ItemOption itemOption){
+        this.defaultItem = itemOption;
+        itemOption.setItem(this);
+    }
 }
 
 

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/Item.java
@@ -107,6 +107,12 @@ public class Item extends Auditable {
     private List<CartItem> cartItemList = new ArrayList<>();
     public Item(Long itemId) {
         this.itemId = itemId;
+        this.defaultItem = new ItemOption();
+        this.optionList = new ArrayList<>();
+        this.cartItemList = new ArrayList<>();
+        this.reviewList = new ArrayList<>();
+        this.questionList = new ArrayList<>();
+        this.pickedItem = new ArrayList<>();
     }
 
     public Item(ItemPostDto post) {

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/ItemOption.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/ItemOption.java
@@ -14,6 +14,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,6 +28,7 @@ import project.main.webstore.domain.order.entity.OrderedItem;
 @Setter
 @Table(name = "ITEM_OPTION")
 @NoArgsConstructor
+@AllArgsConstructor
 public class ItemOption {
     @Id
     @Column(name = "ITEM_OPTION_ID", updatable = false)

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/entity/PickedItem.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/entity/PickedItem.java
@@ -1,18 +1,24 @@
 package project.main.webstore.domain.item.entity;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import project.main.webstore.domain.users.entity.User;
-
-import javax.persistence.*;
-
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.main.webstore.domain.users.entity.User;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
 public class PickedItem {
     @Id
     @GeneratedValue(strategy = IDENTITY)

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/mapper/ItemMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/mapper/ItemMapper.java
@@ -1,12 +1,11 @@
 package project.main.webstore.domain.item.mapper;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
-import project.main.webstore.domain.image.dto.ImageDto;
-import project.main.webstore.domain.image.entity.ItemImage;
+import project.main.webstore.domain.DefaultMapper;
+import project.main.webstore.domain.image.mapper.ImageMapper;
 import project.main.webstore.domain.item.dto.ItemIdResponseDto;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
@@ -18,7 +17,7 @@ import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.item.entity.ItemOption;
 
 @Component
-public class ItemMapper {
+public class ItemMapper extends ImageMapper implements DefaultMapper {
 
     public Item toEntityNew(ItemPostDto post) {
         Item result = Item.builder()
@@ -65,17 +64,6 @@ public class ItemMapper {
         return new ItemOption(0, optionCount, null);
     }
 
-    public List<Long> checkListEmpty(List<Long> list) {
-        if (list == null) {
-            return new ArrayList<>();
-        }
-        return list;
-    }
-
-    public ItemResponseDto toGetResponseDto(Item item) {
-        return new ItemResponseDto(item);
-    }
-
     public ItemResponseDto toGetResponseDtoNew(Item item) {
         return ItemResponseDto.builder()
                 .itemId(item.getItemId())
@@ -88,7 +76,7 @@ public class ItemMapper {
                 .viewCount(item.getViewCount())
                 .optionList(toOptionResponseDtoList(item))
                 .totalCount(item.getTotalCount())
-                .imageList(toImageResponseDtoList(item.getItemImageList()))
+                .imageList(super.toImageResponseDtoList(item.getItemImageList()))
                 .like(item.isLike())
                 .salesQuantity(item.getSalesQuantity())
                 .build();
@@ -96,10 +84,6 @@ public class ItemMapper {
 
     private List<OptionResponseDto> toOptionResponseDtoList(Item item){
         return item.getOptionListWithOutDefault().stream().map(OptionResponseDto::new).collect(Collectors.toList());
-    }
-
-    private List<ImageDto> toImageResponseDtoList(List<ItemImage> imageList){
-        return imageList.stream().map(ImageDto::new).collect(Collectors.toList());
     }
 
     public ItemIdResponseDto toIdResponse(Item item) {
@@ -128,6 +112,9 @@ public class ItemMapper {
         }
 
         return new Item(itemPatchDto, itemId);
+    }
+    public ItemResponseDto toGetResponseDto(Item item) {
+        return new ItemResponseDto(item);
     }
 }
 

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/mapper/ItemMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/mapper/ItemMapper.java
@@ -15,6 +15,7 @@ import project.main.webstore.domain.item.dto.OptionPostRequestDto;
 import project.main.webstore.domain.item.dto.OptionResponseDto;
 import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.item.entity.ItemOption;
+import project.main.webstore.dto.CustomPage;
 
 @Component
 public class ItemMapper extends ImageMapper implements DefaultMapper {
@@ -90,8 +91,9 @@ public class ItemMapper extends ImageMapper implements DefaultMapper {
         return new ItemIdResponseDto(item.getItemId());
     }
 
-    public Page<ItemResponseDto> toGetPageResponse(Page<Item> items) {
-        return items.map(ItemResponseDto::new);
+    public CustomPage<ItemResponseDto> toGetPageResponse(Page<Item> items) {
+        Page<ItemResponseDto> map = items.map(ItemResponseDto::new);
+        return transCustomPage(map);
     }
 
     public List<ItemResponseDto> toGetResponseListDto(List<Item> result) {

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/mapper/ItemMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/mapper/ItemMapper.java
@@ -1,16 +1,17 @@
 package project.main.webstore.domain.item.mapper;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 import project.main.webstore.domain.item.dto.ItemIdResponseDto;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
 import project.main.webstore.domain.item.dto.ItemResponseDto;
+import project.main.webstore.domain.item.dto.OptionPatchDto;
 import project.main.webstore.domain.item.entity.Item;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
+import project.main.webstore.domain.item.entity.ItemOption;
 
 @Component
 public class ItemMapper {
@@ -19,6 +20,29 @@ public class ItemMapper {
             return null;
         }
         return new Item(itemPostDto);
+    }
+    public Item toEntity(ItemPatchDto patch) {
+        Item result = Item.builder()
+                .itemId(patch.getItemId())
+                .category(patch.getCategory())
+                .itemName(patch.getName())
+                .discountRate(patch.getDiscountRate())
+                .description(patch.getDescription())
+                .defaultItem(toDefaultItemOption(patch.getDefaultCount()))
+                .itemPrice(patch.getItemPrice())
+                .deliveryPrice(patch.getDeliveryPrice())
+                .optionList(toOptionList(patch.getUpdateOptionList()))
+                .build();
+        result.getDefaultItem().setItem(result);
+        //TODO : 리펙토링 대상 한번에 올릴 수 있게 해주는 것
+        return result;
+    }
+    private List<ItemOption> toOptionList(List<OptionPatchDto> optionDtoList){
+        //TODO : 리펙토링 대상 : dto 말고 인자로 전달하는 것
+        return optionDtoList.stream().map(dto -> new ItemOption(dto)).collect(Collectors.toList());
+    }
+    private ItemOption toDefaultItemOption(Integer optionCount){
+        return new ItemOption(0,optionCount,null);
     }
 
     public Item itemPatchDtoToItem(ItemPatchDto itemPatchDto, Long itemId) {
@@ -50,7 +74,6 @@ public class ItemMapper {
         return result.stream().map(ItemResponseDto::new).collect(Collectors.toList());
     }
 }
-
 
 
 

--- a/BE/backend/src/main/java/project/main/webstore/domain/item/mapper/ItemMapper.java
+++ b/BE/backend/src/main/java/project/main/webstore/domain/item/mapper/ItemMapper.java
@@ -5,12 +5,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
+import project.main.webstore.domain.image.dto.ImageDto;
+import project.main.webstore.domain.image.entity.ItemImage;
 import project.main.webstore.domain.item.dto.ItemIdResponseDto;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
 import project.main.webstore.domain.item.dto.ItemResponseDto;
 import project.main.webstore.domain.item.dto.OptionPatchDto;
 import project.main.webstore.domain.item.dto.OptionPostRequestDto;
+import project.main.webstore.domain.item.dto.OptionResponseDto;
 import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.item.entity.ItemOption;
 
@@ -47,28 +50,57 @@ public class ItemMapper {
         return result;
     }
 
-    private List<ItemOption> patchToOptionList(List<OptionPatchDto> optionDtoList){
+    private List<ItemOption> patchToOptionList(List<OptionPatchDto> optionDtoList) {
         return optionDtoList.stream().map(dto -> new ItemOption(dto)).collect(Collectors.toList());
     }
-    private List<ItemOption> postToOptionList(List<OptionPostRequestDto> optionDtoList){
-        return optionDtoList.stream().map(option -> new ItemOption(option.getOptionDetail(), option.getAdditionalPrice(), option.getItemCount(),option.getOptionName(), null)).collect(Collectors.toList());
+
+    private List<ItemOption> postToOptionList(List<OptionPostRequestDto> optionDtoList) {
+        return optionDtoList.stream()
+                .map(option -> new ItemOption(option.getOptionDetail(), option.getAdditionalPrice(),
+                        option.getItemCount(), option.getOptionName(), null))
+                .collect(Collectors.toList());
     }
 
-
-    private ItemOption toDefaultItemOption(Integer optionCount){
-        return new ItemOption(0,optionCount,null);
+    private ItemOption toDefaultItemOption(Integer optionCount) {
+        return new ItemOption(0, optionCount, null);
     }
-
 
     public List<Long> checkListEmpty(List<Long> list) {
-        if(list == null)
+        if (list == null) {
             return new ArrayList<>();
+        }
         return list;
     }
+
     public ItemResponseDto toGetResponseDto(Item item) {
         return new ItemResponseDto(item);
     }
 
+    public ItemResponseDto toGetResponseDtoNew(Item item) {
+        return ItemResponseDto.builder()
+                .itemId(item.getItemId())
+                .category(item.getCategory())
+                .name(item.getItemName())
+                .description(item.getDescription())
+                .itemPrice(item.getItemPrice())
+                .deliveryPrice(item.getDeliveryPrice())
+                .defaultCount(item.getDefaultItem().getItemCount())
+                .viewCount(item.getViewCount())
+                .optionList(toOptionResponseDtoList(item))
+                .totalCount(item.getTotalCount())
+                .imageList(toImageResponseDtoList(item.getItemImageList()))
+                .like(item.isLike())
+                .salesQuantity(item.getSalesQuantity())
+                .build();
+    }
+
+    private List<OptionResponseDto> toOptionResponseDtoList(Item item){
+        return item.getOptionListWithOutDefault().stream().map(OptionResponseDto::new).collect(Collectors.toList());
+    }
+
+    private List<ImageDto> toImageResponseDtoList(List<ItemImage> imageList){
+        return imageList.stream().map(ImageDto::new).collect(Collectors.toList());
+    }
 
     public ItemIdResponseDto toIdResponse(Item item) {
         return new ItemIdResponseDto(item.getItemId());
@@ -89,12 +121,13 @@ public class ItemMapper {
         }
         return new Item(itemPostDto);
     }
+
     public Item itemPatchDtoToItem(ItemPatchDto itemPatchDto, Long itemId) {
         if (itemPatchDto == null) {
             return new Item(itemId);
         }
 
-        return new Item(itemPatchDto,itemId);
+        return new Item(itemPatchDto, itemId);
     }
 }
 

--- a/BE/backend/src/main/java/project/main/webstore/dto/CustomPage.java
+++ b/BE/backend/src/main/java/project/main/webstore/dto/CustomPage.java
@@ -1,0 +1,17 @@
+package project.main.webstore.dto;
+
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CustomPage<T> {
+    private List<T> content;
+    private PageInfo pageable;
+
+    public CustomPage(List<T> content, PageInfo pageable) {
+        this.content = content;
+        this.pageable = pageable;
+    }
+}

--- a/BE/backend/src/main/java/project/main/webstore/dto/Dto.java
+++ b/BE/backend/src/main/java/project/main/webstore/dto/Dto.java
@@ -1,0 +1,5 @@
+package project.main.webstore.dto;
+
+public interface Dto {
+
+}

--- a/BE/backend/src/main/java/project/main/webstore/dto/PageInfo.java
+++ b/BE/backend/src/main/java/project/main/webstore/dto/PageInfo.java
@@ -1,0 +1,28 @@
+package project.main.webstore.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PageInfo {
+    private Long offset;
+    private int size;
+    private Long totalElements;
+    private boolean last;
+    private int numberOfElements;
+    private boolean first;
+    private int totalPages;
+
+    public PageInfo(Long offset, int size, Long totalElements, boolean last, int numberOfElements,
+            boolean first, int totalPages) {
+        this.offset = offset;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.last = last;
+        this.numberOfElements = numberOfElements;
+        this.first = first;
+        this.totalPages = totalPages;
+    }
+}
+

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/controller/ItemControllerTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/controller/ItemControllerTest.java
@@ -1,5 +1,6 @@
 package project.main.webstore.domain.item.controller;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.anyList;
 import static org.mockito.BDDMockito.anyLong;
@@ -14,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
@@ -23,26 +25,27 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.util.MultiValueMap;
 import project.main.webstore.annotation.WithMockCustomUser;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
 import project.main.webstore.domain.item.entity.Item;
+import project.main.webstore.domain.item.enums.Category;
 import project.main.webstore.domain.item.service.ItemService;
 import project.main.webstore.domain.item.stub.ItemStub;
 import project.main.webstore.domain.users.enums.UserRole;
-import project.main.webstore.stub.ImageStub;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @MockBean(JpaMetamodelMappingContext.class)
 class ItemControllerTest {
+
     final String DEFAULT_URL = "/api/items";
     @Autowired
     MockMvc mvc;
     @Autowired
     Gson gson;
     ItemStub itemStub = new ItemStub();
-    ImageStub imageStub = new ImageStub();
     @MockBean
     ItemService itemService;
 
@@ -54,14 +57,18 @@ class ItemControllerTest {
         ItemPostDto post = itemStub.createPostDtoWithImage();
         String content = gson.toJson(post);
         Item result = itemStub.createItem(1L);
-        MockMultipartFile multipartFile = new MockMultipartFile("imageList", "originalFilename1.jpg", "jpg", "TEST Mock".getBytes());
-        MockMultipartFile multipartFile2 = new MockMultipartFile("imageList", "originalFilename2.jpg", "jpg", "TEST Mock".getBytes());
-        MockMultipartFile postItem = new MockMultipartFile("post", "post", "application/json", content.getBytes(StandardCharsets.UTF_8));
-
+        MockMultipartFile multipartFile = new MockMultipartFile("imageList",
+                "originalFilename1.jpg", "jpg", "TEST Mock".getBytes());
+        MockMultipartFile multipartFile2 = new MockMultipartFile("imageList",
+                "originalFilename2.jpg", "jpg", "TEST Mock".getBytes());
+        MockMultipartFile postItem = new MockMultipartFile("post", "post", "application/json",
+                content.getBytes(StandardCharsets.UTF_8));
 
         given(itemService.postItem(any(Item.class), anyList())).willReturn(result);
 
-        ResultActions perform = mvc.perform(MockMvcRequestBuilders.multipart(DEFAULT_URL).file(multipartFile2).file(multipartFile).file(postItem).accept(MediaType.APPLICATION_JSON));
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.multipart(DEFAULT_URL).file(multipartFile2)
+                        .file(multipartFile).file(postItem).accept(MediaType.APPLICATION_JSON));
 
         perform
                 .andDo(MockMvcResultHandlers.log())
@@ -76,12 +83,14 @@ class ItemControllerTest {
         ItemPostDto post = itemStub.createPostDtoNoImage();
         String content = gson.toJson(post);
         Item result = itemStub.createItem(1L);
-        MockMultipartFile postItem = new MockMultipartFile("post", "post", "application/json", content.getBytes(StandardCharsets.UTF_8));
-
+        MockMultipartFile postItem = new MockMultipartFile("post", "post", "application/json",
+                content.getBytes(StandardCharsets.UTF_8));
 
         given(itemService.postItem(any(Item.class))).willReturn(result);
 
-        ResultActions perform = mvc.perform(MockMvcRequestBuilders.multipart(DEFAULT_URL).file(postItem).accept(MediaType.APPLICATION_JSON));
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.multipart(DEFAULT_URL).file(postItem)
+                        .accept(MediaType.APPLICATION_JSON));
 
         perform
                 .andDo(MockMvcResultHandlers.log())
@@ -95,11 +104,14 @@ class ItemControllerTest {
     void patch_item_no_image_test() throws Exception {
         ItemPatchDto patch = itemStub.createPatchNoImage();
         String content = gson.toJson(patch);
-        MockMultipartFile patchItem = new MockMultipartFile("patch", "patch", "application/json", content.getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile patchItem = new MockMultipartFile("patch", "patch", "application/json",
+                content.getBytes(StandardCharsets.UTF_8));
         Item item = itemStub.createItem(1L);
         given(itemService.patchItem(any(), any(), any(Item.class), any())).willReturn(item);
 
-        ResultActions perform = mvc.perform(MockMvcRequestBuilders.multipart(HttpMethod.PATCH, DEFAULT_URL + "/{itemId}", 1l).file(patchItem).accept(MediaType.APPLICATION_JSON));
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.multipart(HttpMethod.PATCH, DEFAULT_URL + "/{itemId}", 1l)
+                        .file(patchItem).accept(MediaType.APPLICATION_JSON));
 
         perform
                 .andDo(MockMvcResultHandlers.log())
@@ -113,11 +125,14 @@ class ItemControllerTest {
     void patch_item_delete_image_test() throws Exception {
         ItemPatchDto patch = itemStub.createPatchChangeDeleteImageId();
         String content = gson.toJson(patch);
-        MockMultipartFile patchItem = new MockMultipartFile("patch", "patch", "application/json", content.getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile patchItem = new MockMultipartFile("patch", "patch", "application/json",
+                content.getBytes(StandardCharsets.UTF_8));
         Item item = itemStub.createItem(1L);
         given(itemService.patchItem(any(), any(), any(Item.class), any())).willReturn(item);
 
-        ResultActions perform = mvc.perform(MockMvcRequestBuilders.multipart(HttpMethod.PATCH, DEFAULT_URL + "/{itemId}", 1l).file(patchItem).accept(MediaType.APPLICATION_JSON));
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.multipart(HttpMethod.PATCH, DEFAULT_URL + "/{itemId}", 1l)
+                        .file(patchItem).accept(MediaType.APPLICATION_JSON));
 
         perform
                 .andDo(MockMvcResultHandlers.log())
@@ -131,12 +146,16 @@ class ItemControllerTest {
     void patch_item_change_image_test() throws Exception {
         ItemPatchDto patch = itemStub.createPatchWithImage();
         String content = gson.toJson(patch);
-        MockMultipartFile multipartFile = new MockMultipartFile("imageList", "originalFilename1.jpg", "jpg", "TEST Mock".getBytes());
-        MockMultipartFile patchItem = new MockMultipartFile("patch", "patch", "application/json", content.getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile multipartFile = new MockMultipartFile("imageList",
+                "originalFilename1.jpg", "jpg", "TEST Mock".getBytes());
+        MockMultipartFile patchItem = new MockMultipartFile("patch", "patch", "application/json",
+                content.getBytes(StandardCharsets.UTF_8));
         Item item = itemStub.createItem(1L);
         given(itemService.patchItem(anyList(), anyList(), any(Item.class), any())).willReturn(item);
 
-        ResultActions perform = mvc.perform(MockMvcRequestBuilders.multipart(HttpMethod.PATCH, DEFAULT_URL + "/{itemId}", 1l).file(multipartFile).file(patchItem).accept(MediaType.APPLICATION_JSON));
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.multipart(HttpMethod.PATCH, DEFAULT_URL + "/{itemId}", 1l)
+                        .file(multipartFile).file(patchItem).accept(MediaType.APPLICATION_JSON));
 
         perform
                 .andDo(MockMvcResultHandlers.log())
@@ -146,10 +165,11 @@ class ItemControllerTest {
 
     @Test
     @WithMockCustomUser
-    void deleteItem() throws Exception {
+    void delete_item_test() throws Exception {
         willDoNothing().given(itemService).deleteItem(anyLong());
 
-        ResultActions perform = mvc.perform(MockMvcRequestBuilders.delete(DEFAULT_URL + "/{item-id}", 1L));
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.delete(DEFAULT_URL + "/{item-id}", 1L));
 
         perform
                 .andDo(MockMvcResultHandlers.log())
@@ -159,9 +179,9 @@ class ItemControllerTest {
     @Test
     @DisplayName("상품 단건 조회 : 로그인 한 회원")
     @WithMockCustomUser(userRole = UserRole.CLIENT)
-    void getItem() throws Exception {
+    void get_item_test() throws Exception {
         Item result = itemStub.createItem(1L);
-        given(itemService.getItem(anyLong(),anyLong())).willReturn(result);
+        given(itemService.getItem(anyLong(), anyLong())).willReturn(result);
 
         ResultActions perform = mvc.perform(
                 MockMvcRequestBuilders.get(DEFAULT_URL + "/{item-Id}", 2L));
@@ -169,22 +189,140 @@ class ItemControllerTest {
         perform
                 .andDo(MockMvcResultHandlers.log())
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.itemId").value(result.getItemId()));
+                .andExpect(
+                        MockMvcResultMatchers.jsonPath("$.data.itemId").value(result.getItemId()));
     }
 
     @Test
-    void searchItem() {
+    @DisplayName("상품 단건 조회 : 비회원 회원")
+    void get_item_not_join_user_test() throws Exception {
+        Item result = itemStub.createItem(1L);
+        given(itemService.getItem(anyLong(), anyLong())).willReturn(result);
+
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.get(DEFAULT_URL + "/{item-Id}", 2L));
+
+        perform
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(
+                        MockMvcResultMatchers.jsonPath("$.data.itemId").value(result.getItemId()));
     }
 
     @Test
-    void getItemByCategory() {
+    @DisplayName("이름을 통한 상품 검색 ")
+    @WithMockCustomUser(role = "CLIENT", userRole = UserRole.CLIENT)
+    void search_item_test() throws Exception {
+        MultiValueMap pageParam = itemStub.getPageParam();
+        pageParam.add("itemName", "의자");
+        given(itemService.searchItem(anyString(), any(Pageable.class), anyLong())).willReturn(
+                itemStub.createPageItem(3L));
+
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.get(DEFAULT_URL + "/search/itemName").params(pageParam));
+
+        perform
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].itemId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[1].itemId").value(2L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.pageable.pageSize").value(30));
+
     }
 
     @Test
-    void getItemByHighPrice() {
+    @DisplayName("카테고리 별 상품 조회")
+    void search_item_by_category_test() throws Exception {
+        MultiValueMap pageParam = itemStub.getPageParam();
+        pageParam.add("category", "CHAIR");
+        given(itemService.findItemByCategory(any(Category.class), any(Pageable.class),
+                anyLong())).willReturn(itemStub.createPageItem(3L));
+
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.get(DEFAULT_URL + "/search/category").params(pageParam));
+
+        perform
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].itemId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[1].itemId").value(2L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.pageable.pageSize").value(30));
+
     }
 
     @Test
-    void pickItem() {
+    @DisplayName("찜한 상품 조회")
+    @WithMockCustomUser
+    void get_pick_item_test() throws Exception {
+
+        given(itemService.getPickedItem(anyLong())).willReturn(itemStub.createPickedItemList(4L));
+        ResultActions perform = mvc.perform(MockMvcRequestBuilders.get(DEFAULT_URL + "/favorite"));
+
+        perform
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].itemId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].like").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].like").value(true));
+    }
+
+    @Test
+    @DisplayName("찜하기 : 찜하기")
+    @WithMockCustomUser(role = "CLIENT", userId = 1L, userRole = UserRole.CLIENT)
+    void post_pick_item_test() throws Exception {
+
+        given(itemService.pickItem(anyLong(), anyLong())).willReturn(
+                itemStub.createPickedItemDto(1L, 1L, true));
+
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.post(DEFAULT_URL + "/{itemId}/favorite", 1L));
+
+        perform
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.userId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.itemId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.picked").value(true));
+    }
+
+    @Test
+    @DisplayName("찜하기 : 찜취소하기")
+    @WithMockCustomUser(role = "CLIENT", userId = 1L, userRole = UserRole.CLIENT)
+    void post_pick_item_cancel_test() throws Exception {
+
+        given(itemService.pickItem(anyLong(), anyLong())).willReturn(
+                itemStub.createPickedItemDto(1L, 1L, false));
+
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.post(DEFAULT_URL + "/{itemId}/favorite", 1L));
+
+        perform
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.userId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.itemId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.picked").value(false));
+
+    }
+
+    @Test
+    @DisplayName("전체 조회")
+    void get_all_page() throws Exception {
+        MultiValueMap pageParam = itemStub.getPageParam();
+        given(itemService.findItemPage(any(Pageable.class), anyLong())).willReturn(
+                itemStub.createPageItem(5L));
+
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.get(DEFAULT_URL).params(pageParam));
+
+        perform
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[0].itemId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.content[1].itemId").value(2L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("작업 완료"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.code").value("C200"))
+
+        ;
     }
 }

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/controller/ItemControllerTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/controller/ItemControllerTest.java
@@ -1,6 +1,13 @@
 package project.main.webstore.domain.item.controller;
 
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyList;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+
 import com.google.gson.Gson;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,11 +29,8 @@ import project.main.webstore.domain.item.dto.ItemPostDto;
 import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.item.service.ItemService;
 import project.main.webstore.domain.item.stub.ItemStub;
+import project.main.webstore.domain.users.enums.UserRole;
 import project.main.webstore.stub.ImageStub;
-
-import java.nio.charset.StandardCharsets;
-
-import static org.mockito.BDDMockito.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -153,10 +157,20 @@ class ItemControllerTest {
     }
 
     @Test
-    void getItem() {
+    @DisplayName("상품 단건 조회 : 로그인 한 회원")
+    @WithMockCustomUser(userRole = UserRole.CLIENT)
+    void getItem() throws Exception {
+        Item result = itemStub.createItem(1L);
+        given(itemService.getItem(anyLong(),anyLong())).willReturn(result);
 
+        ResultActions perform = mvc.perform(
+                MockMvcRequestBuilders.get(DEFAULT_URL + "/{item-Id}", 2L));
+
+        perform
+                .andDo(MockMvcResultHandlers.log())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.itemId").value(result.getItemId()));
     }
-
 
     @Test
     void searchItem() {

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/controller/ItemControllerTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/controller/ItemControllerTest.java
@@ -255,7 +255,7 @@ class ItemControllerTest {
     @WithMockCustomUser
     void get_pick_item_test() throws Exception {
 
-        given(itemService.getPickedItem(anyLong())).willReturn(itemStub.createPickedItemList(4L));
+        given(itemService.getPickedItem(anyLong())).willReturn(itemStub.createItemWhoPickedList(4L));
         ResultActions perform = mvc.perform(MockMvcRequestBuilders.get(DEFAULT_URL + "/favorite"));
 
         perform

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/mapper/ItemMapperTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/mapper/ItemMapperTest.java
@@ -1,0 +1,31 @@
+package project.main.webstore.domain.item.mapper;
+
+
+import java.util.ArrayList;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import project.main.webstore.domain.item.dto.ItemPatchDto;
+import project.main.webstore.domain.item.entity.Item;
+import project.main.webstore.domain.item.enums.Category;
+
+
+class ItemMapperTest {
+
+    ItemMapper mapper = new ItemMapper();
+
+
+    @Test
+    @DisplayName("patch DTO 수정을 위한 테스트 : List들이 빈 값이 들어올 떄 처리 로직")
+    void patch_trans_test() throws Exception {
+        ItemPatchDto itemPatchDto = new ItemPatchDto(1L, Category.CHAIR, "의자", "설명", 100, 10000,
+                3000, 0, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                new ArrayList<>());
+
+        Item newOne = mapper.toEntity(itemPatchDto);
+        Item oldOne = mapper.itemPatchDtoToItem(itemPatchDto, 1L);
+
+        Assertions.assertThat(newOne).as("두 값은 동일해야한다.").usingRecursiveComparison()
+                .isEqualTo(oldOne);
+    }
+}

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/mapper/ItemMapperTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/mapper/ItemMapperTest.java
@@ -7,14 +7,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
+import project.main.webstore.domain.item.dto.ItemResponseDto;
 import project.main.webstore.domain.item.entity.Item;
+import project.main.webstore.domain.item.entity.ItemOption;
 import project.main.webstore.domain.item.enums.Category;
 
 
 class ItemMapperTest {
-
     ItemMapper mapper = new ItemMapper();
-
 
     @Test
     @DisplayName("patch DTO 수정을 위한 테스트 : List들이 빈 값이 들어올 떄 처리 로직")
@@ -43,4 +43,20 @@ class ItemMapperTest {
                 .isEqualTo(oldOne);
     }
 
+
+
+
+    @Test
+    @DisplayName("Entity -> DTO 변환 테스트")
+    void entity_trans_to_dto_test() throws Exception{
+        Item entity = new Item(new ArrayList<>(), 1L, "상품", "상품 설명", 30000, 3000, 0, Category.CHAIR,
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                new ArrayList<>(), new ItemOption(0,1000,null));
+
+        ItemResponseDto newOne = mapper.toGetResponseDtoNew(entity);
+        ItemResponseDto oldOne = mapper.toGetResponseDto(entity);
+
+        Assertions.assertThat(newOne).as("두 값은 동일해야한다.").usingRecursiveComparison()
+                .isEqualTo(oldOne);
+    }
 }

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/mapper/ItemMapperTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/mapper/ItemMapperTest.java
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
+import project.main.webstore.domain.item.dto.ItemPostDto;
 import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.item.enums.Category;
 
@@ -28,4 +29,18 @@ class ItemMapperTest {
         Assertions.assertThat(newOne).as("두 값은 동일해야한다.").usingRecursiveComparison()
                 .isEqualTo(oldOne);
     }
+
+    @Test
+    @DisplayName("post DTO 수정을 위한 테스트")
+    void post_trans_test() throws Exception{
+        ItemPostDto post = new ItemPostDto(Category.CHAIR, "의자", 0, "상세 설명", 10000,
+                100, 3000, new ArrayList<>(), new ArrayList<>());
+
+        Item oldOne = mapper.toEntity(post);
+        Item newOne = mapper.toEntityNew(post);
+
+        Assertions.assertThat(newOne).as("두 값은 동일해야한다.").usingRecursiveComparison()
+                .isEqualTo(oldOne);
+    }
+
 }

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/service/ItemServiceTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/service/ItemServiceTest.java
@@ -1,5 +1,15 @@
 package project.main.webstore.domain.item.service;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,15 +29,6 @@ import project.main.webstore.domain.item.stub.ItemStub;
 import project.main.webstore.domain.users.service.UserValidService;
 import project.main.webstore.exception.BusinessLogicException;
 import project.main.webstore.exception.CommonExceptionCode;
-import project.main.webstore.stub.ImageStub;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class})
 class ItemServiceTest {
@@ -42,14 +43,13 @@ class ItemServiceTest {
     @Mock
     ImageUtils imageUtils;
     ItemStub itemStub = new ItemStub();
-    ImageStub imageStub = new ImageStub();
 
     @Test
     @DisplayName("상품 등록[이미지 없음] : 성공")
     void post_item_no_image_test() throws Exception {
         // given
         Item item = itemStub.createItem(1L);
-        Item itemNoId = itemStub.createItemNoId();
+        Item itemNoId = itemStub.createItemNoId(1L);
         given(itemRepository.save(ArgumentMatchers.any(Item.class))).willReturn(item);
         // when
         Item result = service.postItem(itemNoId);
@@ -66,9 +66,9 @@ class ItemServiceTest {
     void post_item_test() throws Exception {
         // given
         Item item = itemStub.createItem(1L);
-        Item itemNoId = itemStub.createItemNoId();
-        List<ImageInfoDto> imageInfo = imageStub.createImageInfo(1, true);
-        List<Image> imageList = imageStub.createImageList(2);
+        Item itemNoId = itemStub.createItemNoId(1L);
+        List<ImageInfoDto> imageInfo = itemStub.createImageInfo(1, true);
+        List<Image> imageList = itemStub.createImageList(2);
 
         given(imageUtils.uploadImageList(anyList())).willReturn(imageList);
         given(itemRepository.save(ArgumentMatchers.any(Item.class))).willReturn(item);
@@ -103,8 +103,8 @@ class ItemServiceTest {
     @DisplayName("상품 수정[이미지 및 상품] : 성공")
     void patch_item_delete_image_test() throws Exception {
         // given
-        List<ImageInfoDto> imageInfo = imageStub.createImageInfo(1, true);
-        List<Image> imageList = imageStub.createImageList(2);
+        List<ImageInfoDto> imageInfo = itemStub.createImageInfo(1, true);
+        List<Image> imageList = itemStub.createImageList(2);
         Item itemByPatchNoImage = itemStub.createItemByPatchNoImage();
         itemByPatchNoImage.setItemId(1L);
         Item item = itemStub.createItem(1L);
@@ -147,8 +147,8 @@ class ItemServiceTest {
     @Test
     @DisplayName("상품 수정[이미지 삽입] : 실패")
     void patch_item_image_exception_test() throws Exception {
-        List<ImageInfoDto> imageInfo = imageStub.createImageInfo(1, true);
-        List<Image> imageList = imageStub.createImageList(2);
+        List<ImageInfoDto> imageInfo = itemStub.createImageInfo(1, true);
+        List<Image> imageList = itemStub.createImageList(2);
         Item itemByPatchNoImage = itemStub.createItemByPatchNoImage();
         itemByPatchNoImage.setItemId(1L);
         Item item = itemStub.createItem(1L);
@@ -180,7 +180,7 @@ class ItemServiceTest {
         // given
         Long itemId = 1L;
         Item item = itemStub.createItem(1L);
-        List<Image> imageList = imageStub.createImageList(2);
+        List<Image> imageList = itemStub.createImageList(2);
         List<ItemImage> image = imageList.stream().map(imageE -> new ItemImage(imageE, item)).collect(Collectors.toList());
         item.setItemImageList(image);
 

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
 import project.main.webstore.domain.image.dto.ImageSortPatchDto;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
@@ -17,6 +18,7 @@ import project.main.webstore.domain.item.enums.Category;
 import project.main.webstore.domain.users.entity.User;
 import project.main.webstore.stub.ImageStub;
 
+@Component
 public class ItemStub extends ImageStub {
     public ItemPostDto createPostDtoWithImage(){
         return new ItemPostDto(Category.COMPUTER,"맥북",10,"이것 맥북의 설명입니다.",1000000,100,3000, createOptionPostList(),createImageList());

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
@@ -121,6 +121,19 @@ public class ItemStub extends ImageStub {
                 .deleteImageId(List.of(1L))
                 .build();
     }
+    public ItemPatchDto createPatchWithImageWithTotal() {
+        return ItemPatchDto.builder()
+                .category(Category.CHAIR)
+                .name("의자")
+                .description("이것은 의자 상품입니다")
+                .itemPrice(10000)
+                .discountRate(0)
+                .deliveryPrice(3000)
+                .defaultCount(100)
+                .imageSortAndRepresentativeInfo(List.of(new ImageSortPatchDto(1L,2,false),new ImageSortPatchDto(2L,1,false),new ImageSortPatchDto(null,3,true),new ImageSortPatchDto(null,4,false)))
+                .deleteImageId(List.of(1L))
+                .build();
+    }
     public ItemPatchDto createPatchWithImageTwo() {
         return ItemPatchDto.builder()
                 .category(Category.CHAIR)

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
@@ -9,6 +9,7 @@ import project.main.webstore.domain.image.dto.ImageSortPatchDto;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
 import project.main.webstore.domain.item.dto.OptionPostRequestDto;
+import project.main.webstore.domain.item.dto.PickedItemDto;
 import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.item.entity.ItemOption;
 import project.main.webstore.domain.item.enums.Category;
@@ -37,6 +38,7 @@ public class ItemStub extends ImageStub {
         return item;
     }
 
+
     //요청 데이터로 사용
     public Item createItemNoId(Long index) {
         Item item = Item.builder()
@@ -57,6 +59,20 @@ public class ItemStub extends ImageStub {
         return new PageImpl<>(list,pageInfo,30);
     }
 
+    private List<Item> createItemList(Long limit) {
+        List<Item> list = new ArrayList<>();
+        for(long i = 1L; i < limit;i++){
+            list.add(createItem(i));
+        }
+        return list;
+    }
+    public List<Item> createPickedItemList(Long limit) {
+        List<Item> list = new ArrayList<>();
+        for(long i = 1L; i < limit;i++){
+            list.add(createItem(i,true));
+        }
+        return list;
+    }
 
     public Item createItemByPatchNoImage() {
         Item item = Item.builder()
@@ -113,7 +129,10 @@ public class ItemStub extends ImageStub {
                 .build();
     }
 
-    //리펙토링 필요
+    public PickedItemDto createPickedItemDto(Long userId,Long itemId, boolean isPicked) {
+        return new PickedItemDto(userId,itemId,isPicked);
+    }
+
     private List<OptionPostRequestDto> createOptionPostList(){
         return List.of(
                 new OptionPostRequestDto("옵션 상세 설정1",100,100000,"옵션 이름1"),
@@ -122,7 +141,6 @@ public class ItemStub extends ImageStub {
                 new OptionPostRequestDto("옵션 상세 설정4",400,400000,"옵션 이름4")
         );
     }
-    //리펙토링 필요
     private List<ItemOption> createOptionListNoId() {
         List<ItemOption> list = new ArrayList<>();
         for(Long i = 2L ; i <=4L ; i++){
@@ -150,11 +168,19 @@ public class ItemStub extends ImageStub {
         return new ItemOption(optionId,"",null,100,null);
     }
 
-    private List<Item> createItemList(Long limit) {
-        List<Item> list = new ArrayList<>();
-        for(long i = 1L; i < limit;i++){
-            list.add(createItem(i));
-        }
-        return list;
+    private Item createItem(Long itemId,boolean isPicked) {
+        Item item = Item.builder()
+                .itemId(itemId)
+                .itemName("상품 이름" + itemId)
+                .itemPrice((int)(3000 * (itemId * 1000)))
+                .deliveryPrice((int)(itemId * 1000))
+                .discountRate(0)
+                .like(isPicked)
+                .category(Category.CHAIR)
+                .build();
+        item.addDefaultItem(createDefaultOption(1L));
+        item.addOptionList(createOptionListWithId());
+        return item;
     }
+
 }

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
@@ -1,7 +1,11 @@
 package project.main.webstore.domain.item.stub;
 
+import java.util.ArrayList;
 import java.util.List;
-import project.main.webstore.domain.image.dto.ImageSortPostDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import project.main.webstore.domain.image.dto.ImageSortPatchDto;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
 import project.main.webstore.domain.item.dto.OptionPostRequestDto;
@@ -11,11 +15,6 @@ import project.main.webstore.domain.item.enums.Category;
 import project.main.webstore.stub.ImageStub;
 
 public class ItemStub extends ImageStub {
-
-    public Item createItem(Long itemId){
-        return new Item(itemId,"상품 이름","상품 상세 설명",10000,3000,10,Category.CHAIR, createOptionList());
-    }
-
     public ItemPostDto createPostDtoWithImage(){
         return new ItemPostDto(Category.COMPUTER,"맥북",10,"이것 맥북의 설명입니다.",1000000,100,3000, createOptionPostList(),createImageList());
     }
@@ -23,38 +22,98 @@ public class ItemStub extends ImageStub {
         return new ItemPostDto(Category.COMPUTER,"맥북",10,"이것 맥북의 설명입니다.",1000000,100,3000, createOptionPostList());
     }
 
-    public Item createItemNoId() {
-        return new Item(createPostDtoWithImage());
+    //응답 데이터 용으로 사용
+    public Item createItem(Long itemId) {
+        Item item = Item.builder()
+                .itemId(itemId)
+                .itemName("상품 이름" + itemId)
+                .itemPrice((int)(3000 * (itemId * 1000)))
+                .deliveryPrice((int)(itemId * 1000))
+                .discountRate(0)
+                .category(Category.CHAIR)
+                .build();
+        item.addDefaultItem(createDefaultOption(1L));
+        item.addOptionList(createOptionListWithId());
+        return item;
     }
+
+    //요청 데이터로 사용
+    public Item createItemNoId(Long index) {
+        Item item = Item.builder()
+                .itemName("상품 이름" + index)
+                .itemPrice((int)(3000 * (index * 1000)))
+                .deliveryPrice((int)(index * 1000))
+                .discountRate(0)
+                .category(Category.CHAIR)
+                .build();
+        item.addDefaultItem(createDefaultOption());
+        item.addOptionList(createOptionListNoId());
+        return item;
+    }
+
+    public Page<Item> createPageItem(Long limit){
+        List<Item> list = createItemList(limit);
+        Pageable pageInfo = super.getPage();
+        return new PageImpl<>(list,pageInfo,30);
+    }
+
 
     public Item createItemByPatchNoImage() {
-        return new Item(createPatchNoImage(),1L);
-    }
-
-    public Item createItemByPatchWithImage() {
-        return new Item(createPatchWithImage(),1L);
-    }
-
-    public Item createItemByPatchChangeImage() {
-        return new Item(createPatchWithImage(),1L);
+        Item item = Item.builder()
+                .category(Category.CHAIR)
+                .itemName("의자")
+                .description("이것은 의자 상품입니다")
+                .itemPrice(10000)
+                .deliveryPrice(3000)
+                .discountRate(0)
+                .build();
+        item.addDefaultItem(new ItemOption(0,100,null));
+        return item;
     }
 
     public ItemPatchDto createPatchNoImage(){
         return new ItemPatchDto(Category.CHAIR,"의자","이것은 의자 상품입니다",100,10000,300,10);
     }
     public ItemPatchDto createPatchWithImage() {
-        //TODO : Mapper 변경 이 후 수정
-//        return new ItemPatchDto(Category.CHAIR,"의자","이것은 의자 상품입니다",100,10000,300,10,List.of(1L),null,null,List.of(new ImageSortPatchDto(1L,2,false)));
-        return null;
+        return ItemPatchDto.builder()
+                .category(Category.CHAIR)
+                .name("의자")
+                .description("이것은 의자 상품입니다")
+                .itemPrice(10000)
+                .discountRate(0)
+                .deliveryPrice(3000)
+                .defaultCount(100)
+                .imageSortAndRepresentativeInfo(List.of(new ImageSortPatchDto(1L,2,false)))
+                .deleteImageId(List.of(1L))
+                .build();
     }
     public ItemPatchDto createPatchWithImageTwo() {
-//        return new ItemPatchDto(Category.CHAIR,"의자","이것은 의자 상품입니다",100,10000,300,10,List.of(1L),null,null,List.of(new ImageSortPatchDto(1L,2,false),new ImageSortPatchDto(null,1,true),new ImageSortPatchDto(null,2,false)));
-        return null;
+        return ItemPatchDto.builder()
+                .category(Category.CHAIR)
+                .name("의자")
+                .description("이것은 의자 상품입니다")
+                .itemPrice(10000)
+                .discountRate(0)
+                .deliveryPrice(3000)
+                .defaultCount(100)
+                .imageSortAndRepresentativeInfo(List.of(new ImageSortPatchDto(1L,2,false),new ImageSortPatchDto(null,1,true),new ImageSortPatchDto(null,2,false)))
+                .deleteImageId(List.of(1L))
+                .build();
     }
     public ItemPatchDto createPatchChangeDeleteImageId() {
-        return new ItemPatchDto(Category.CHAIR,"의자","이것은 의자 상품입니다",100,10000,300,10,List.of(1L));
+        return ItemPatchDto.builder()
+                .category(Category.CHAIR)
+                .name("의자")
+                .description("이것은 의자 상품입니다")
+                .itemPrice(10000)
+                .discountRate(0)
+                .deliveryPrice(3000)
+                .defaultCount(100)
+                .deleteImageId(List.of(1L))
+                .build();
     }
 
+    //리펙토링 필요
     private List<OptionPostRequestDto> createOptionPostList(){
         return List.of(
                 new OptionPostRequestDto("옵션 상세 설정1",100,100000,"옵션 이름1"),
@@ -63,19 +122,39 @@ public class ItemStub extends ImageStub {
                 new OptionPostRequestDto("옵션 상세 설정4",400,400000,"옵션 이름4")
         );
     }
-
-    private List<ItemOption> createOptionList() {
-        return List.of(
-                new ItemOption("옵션 설명 1",100,10000,"옵션 이름1"),
-                new ItemOption("옵션 설명 2",200,20000,"옵션 이름2"),
-                new ItemOption("옵션 설명 3",300,30000,"옵션 이름3")
-        );
+    //리펙토링 필요
+    private List<ItemOption> createOptionListNoId() {
+        List<ItemOption> list = new ArrayList<>();
+        for(Long i = 2L ; i <=4L ; i++){
+            list.add(createOptionNoId(i));
+        }
+        return list;
     }
-    private List<ImageSortPostDto> createImageList(){
-        return List.of(
-                new ImageSortPostDto(0,false),
-                new ImageSortPostDto(1,true)
-        );
+    private List<ItemOption> createOptionListWithId() {
+        List<ItemOption> list = new ArrayList<>();
+        for(Long i = 2L ; i <=4L ; i++){
+            list.add(createOption(i));
+        }
+        return list;
+    }
+    private ItemOption createOption(Long optionId) {
+        return new ItemOption(optionId,"옵션 설명" + optionId,null,100,10000,false,null,new ArrayList<>(), new ArrayList<>());
+    }
+    private ItemOption createOptionNoId(Long index) {
+        return new ItemOption("옵션 설명" + index,100,10000,"옵션 이름" + index);
+    }
+    private ItemOption createDefaultOption() {
+        return new ItemOption(0,100,null);
+    }
+    private ItemOption createDefaultOption(Long optionId) {
+        return new ItemOption(optionId,"",null,100,null);
     }
 
+    private List<Item> createItemList(Long limit) {
+        List<Item> list = new ArrayList<>();
+        for(long i = 1L; i < limit;i++){
+            list.add(createItem(i));
+        }
+        return list;
+    }
 }

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
@@ -12,7 +12,9 @@ import project.main.webstore.domain.item.dto.OptionPostRequestDto;
 import project.main.webstore.domain.item.dto.PickedItemDto;
 import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.item.entity.ItemOption;
+import project.main.webstore.domain.item.entity.PickedItem;
 import project.main.webstore.domain.item.enums.Category;
+import project.main.webstore.domain.users.entity.User;
 import project.main.webstore.stub.ImageStub;
 
 public class ItemStub extends ImageStub {
@@ -21,6 +23,10 @@ public class ItemStub extends ImageStub {
     }
     public ItemPostDto createPostDtoNoImage(){
         return new ItemPostDto(Category.COMPUTER,"맥북",10,"이것 맥북의 설명입니다.",1000000,100,3000, createOptionPostList());
+    }
+
+    public Item createItemOnlyId(Long itemId) {
+        return new Item(itemId);
     }
 
     //응답 데이터 용으로 사용
@@ -58,6 +64,18 @@ public class ItemStub extends ImageStub {
         Pageable pageInfo = super.getPage();
         return new PageImpl<>(list,pageInfo,30);
     }
+    public Page<Item> createPageItemNameSame(Long limit,String word){
+        List<Item> list = createItemList(limit);
+        for (Item item : list) {
+            item.setItemName(word);
+        }
+        Pageable pageInfo = super.getPage();
+        return new PageImpl<>(list,pageInfo,30);
+    }
+
+    public Page<Item> createEmptyPage(Pageable pageable){
+        return new PageImpl<>(new ArrayList<>(),pageable,0);
+    }
 
     private List<Item> createItemList(Long limit) {
         List<Item> list = new ArrayList<>();
@@ -66,7 +84,7 @@ public class ItemStub extends ImageStub {
         }
         return list;
     }
-    public List<Item> createPickedItemList(Long limit) {
+    public List<Item> createItemWhoPickedList(Long limit) {
         List<Item> list = new ArrayList<>();
         for(long i = 1L; i < limit;i++){
             list.add(createItem(i,true));
@@ -183,4 +201,11 @@ public class ItemStub extends ImageStub {
         return item;
     }
 
+    public List<PickedItem> createPickedList(long limit) {
+        List<PickedItem> list = new ArrayList<>();
+        for(Long i = 1L ; i <= limit ; i++){
+            list.add(new PickedItem(i,new Item(i + 10L),new User(i + 20L)));
+        }
+        return list;
+    }
 }

--- a/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/item/stub/ItemStub.java
@@ -1,6 +1,6 @@
 package project.main.webstore.domain.item.stub;
 
-import project.main.webstore.domain.image.dto.ImageSortPatchDto;
+import java.util.List;
 import project.main.webstore.domain.image.dto.ImageSortPostDto;
 import project.main.webstore.domain.item.dto.ItemPatchDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
@@ -8,10 +8,9 @@ import project.main.webstore.domain.item.dto.OptionPostRequestDto;
 import project.main.webstore.domain.item.entity.Item;
 import project.main.webstore.domain.item.entity.ItemOption;
 import project.main.webstore.domain.item.enums.Category;
+import project.main.webstore.stub.ImageStub;
 
-import java.util.List;
-
-public class ItemStub {
+public class ItemStub extends ImageStub {
 
     public Item createItem(Long itemId){
         return new Item(itemId,"상품 이름","상품 상세 설명",10000,3000,10,Category.CHAIR, createOptionList());
@@ -44,10 +43,13 @@ public class ItemStub {
         return new ItemPatchDto(Category.CHAIR,"의자","이것은 의자 상품입니다",100,10000,300,10);
     }
     public ItemPatchDto createPatchWithImage() {
-        return new ItemPatchDto(Category.CHAIR,"의자","이것은 의자 상품입니다",100,10000,300,10,List.of(1L),null,null,List.of(new ImageSortPatchDto(1L,2,false)));
+        //TODO : Mapper 변경 이 후 수정
+//        return new ItemPatchDto(Category.CHAIR,"의자","이것은 의자 상품입니다",100,10000,300,10,List.of(1L),null,null,List.of(new ImageSortPatchDto(1L,2,false)));
+        return null;
     }
     public ItemPatchDto createPatchWithImageTwo() {
-        return new ItemPatchDto(Category.CHAIR,"의자","이것은 의자 상품입니다",100,10000,300,10,List.of(1L),null,null,List.of(new ImageSortPatchDto(1L,2,false),new ImageSortPatchDto(null,1,true),new ImageSortPatchDto(null,2,false)));
+//        return new ItemPatchDto(Category.CHAIR,"의자","이것은 의자 상품입니다",100,10000,300,10,List.of(1L),null,null,List.of(new ImageSortPatchDto(1L,2,false),new ImageSortPatchDto(null,1,true),new ImageSortPatchDto(null,2,false)));
+        return null;
     }
     public ItemPatchDto createPatchChangeDeleteImageId() {
         return new ItemPatchDto(Category.CHAIR,"의자","이것은 의자 상품입니다",100,10000,300,10,List.of(1L));

--- a/BE/backend/src/test/java/project/main/webstore/domain/users/stub/UserStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/domain/users/stub/UserStub.java
@@ -1,14 +1,12 @@
 package project.main.webstore.domain.users.stub;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.security.core.parameters.P;
 import project.main.webstore.domain.cart.entity.Cart;
 import project.main.webstore.domain.users.dto.UserGetResponseDto;
 import project.main.webstore.domain.users.entity.User;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class UserStub {
     public User createUser(Long id) {

--- a/BE/backend/src/test/java/project/main/webstore/helper/TestUtils.java
+++ b/BE/backend/src/test/java/project/main/webstore/helper/TestUtils.java
@@ -1,8 +1,10 @@
 package project.main.webstore.helper;
 
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -11,8 +13,6 @@ import org.springframework.util.MultiValueMap;
 import project.main.webstore.domain.users.enums.UserRole;
 import project.main.webstore.security.dto.UserInfoDto;
 import project.main.webstore.security.jwt.utils.JwtTokenizer;
-
-import java.util.List;
 
 @Component
 public class TestUtils {
@@ -46,6 +46,19 @@ public class TestUtils {
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
 
         return headers;
+    }
+    public HttpHeaders getMultipartHeader(){
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+        return headers;
+    }
+    public HttpEntity<String> getJsonRequestHeader(String jsonData){
+
+        HttpHeaders jsonRequest = new HttpHeaders();
+        jsonRequest.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity<String>(jsonData, jsonRequest);
     }
 
     public MultiValueMap getPageParam(){

--- a/BE/backend/src/test/java/project/main/webstore/helper/TestUtils.java
+++ b/BE/backend/src/test/java/project/main/webstore/helper/TestUtils.java
@@ -17,7 +17,17 @@ import project.main.webstore.security.jwt.utils.JwtTokenizer;
 @Component
 public class TestUtils {
     @Autowired
-    JwtTokenizer jwtTokenizer;
+    private JwtTokenizer jwtTokenizer;
+    public String getJWTAccessTokenAdmin(){
+        UserInfoDto userInfo = new UserInfoDto("2", "admin@gmail.com", "김복자", UserRole.ADMIN);
+        return jwtTokenizer.delegateAccessToken(userInfo);
+
+    }
+    public String getJWTAccessTokenClient(){
+        UserInfoDto userInfo = new UserInfoDto("1", "client@gmail.com", "김복자", UserRole.CLIENT);
+        return jwtTokenizer.delegateAccessToken(userInfo);
+
+    }
     public HttpHeaders getJWTAdmin(){
         UserInfoDto userInfo = new UserInfoDto("2", "admin@gmail.com", "김복자", UserRole.ADMIN);
         String accessToken = jwtTokenizer.delegateAccessToken(userInfo);
@@ -33,6 +43,14 @@ public class TestUtils {
         UserInfoDto userInfo = new UserInfoDto("1", "client@gmail.com", "김복자", UserRole.CLIENT);
         String accessToken = jwtTokenizer.delegateAccessToken(userInfo);
 
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(accessToken);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+        return headers;
+    }
+    public HttpHeaders getLoginHeader(String accessToken){
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth(accessToken);

--- a/BE/backend/src/test/java/project/main/webstore/stub/ImageStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/stub/ImageStub.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,6 +21,7 @@ import project.main.webstore.domain.image.dto.ImageSortPostDto;
 import project.main.webstore.domain.image.entity.Image;
 import project.main.webstore.helper.TestUtils;
 
+@Component
 public class ImageStub extends TestUtils {
     private String fileName = "testImage";
     private String ext = "png";
@@ -133,17 +135,21 @@ public class ImageStub extends TestUtils {
         );
     }
 
-    public HttpEntity<MultiValueMap<String, Object>> getMultipartTwoImageAndJsonDataRequest(String method,String content)
+    public HttpEntity<MultiValueMap<String, Object>> getMultipartTwoImageAndJsonDataRequest(String method,String content,String accessToken)
             throws IOException {
         HttpHeaders header = getMultipartHeader();
+        HttpHeaders jwtAdmin = getLoginHeader(accessToken);
+        header.addAll(jwtAdmin);
         MultiValueMap<String, Object> requestBody = createMultipartTwoFileAndJsonRequest(method,content);
 
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(requestBody, header);
         return requestEntity;
     }
-    public HttpEntity<MultiValueMap<String, Object>> getMultipartJsonDataRequest(String method,String content)
+    public HttpEntity<MultiValueMap<String, Object>> getMultipartJsonDataRequest(String method,String content,String accessToken)
             throws IOException {
         HttpHeaders header = getMultipartHeader();
+        HttpHeaders jwtAdmin = getLoginHeader(accessToken);
+        header.addAll(jwtAdmin);
         MultiValueMap<String, Object> requestBody = createMultiPartOnlyJson(method,content);
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(requestBody, header);
         return requestEntity;

--- a/BE/backend/src/test/java/project/main/webstore/stub/ImageStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/stub/ImageStub.java
@@ -1,5 +1,10 @@
 package project.main.webstore.stub;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -7,14 +12,9 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import project.main.webstore.domain.image.dto.ImageInfoDto;
 import project.main.webstore.domain.image.entity.Image;
+import project.main.webstore.helper.TestUtils;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-public class ImageStub {
+public class ImageStub extends TestUtils {
     private String fileName = "testImage";
     private String ext = "png";
     private String path = "src/test/resources/image/testImage";

--- a/BE/backend/src/test/java/project/main/webstore/stub/ImageStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/stub/ImageStub.java
@@ -11,6 +11,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import project.main.webstore.domain.image.dto.ImageInfoDto;
+import project.main.webstore.domain.image.dto.ImageSortPostDto;
 import project.main.webstore.domain.image.entity.Image;
 import project.main.webstore.helper.TestUtils;
 
@@ -136,6 +137,13 @@ public class ImageStub extends TestUtils {
             }
         };
         return bytes;
+    }
+
+    protected List<ImageSortPostDto> createImageList(){
+        return List.of(
+                new ImageSortPostDto(0,false),
+                new ImageSortPostDto(1,true)
+        );
     }
 
 }

--- a/BE/backend/src/test/java/project/main/webstore/stub/ImageStub.java
+++ b/BE/backend/src/test/java/project/main/webstore/stub/ImageStub.java
@@ -133,18 +133,18 @@ public class ImageStub extends TestUtils {
         );
     }
 
-    public HttpEntity<MultiValueMap<String, Object>> getMultipartTwoImageAndJsonDataRequest(String content)
+    public HttpEntity<MultiValueMap<String, Object>> getMultipartTwoImageAndJsonDataRequest(String method,String content)
             throws IOException {
         HttpHeaders header = getMultipartHeader();
-        MultiValueMap<String, Object> requestBody = createMultipartTwoFileAndJsonRequest(content);
+        MultiValueMap<String, Object> requestBody = createMultipartTwoFileAndJsonRequest(method,content);
 
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(requestBody, header);
         return requestEntity;
     }
-    public HttpEntity<MultiValueMap<String, Object>> getMultipartJsonDataRequest(String content)
+    public HttpEntity<MultiValueMap<String, Object>> getMultipartJsonDataRequest(String method,String content)
             throws IOException {
         HttpHeaders header = getMultipartHeader();
-        MultiValueMap<String, Object> requestBody = createMultiPartOnlyJson(content);
+        MultiValueMap<String, Object> requestBody = createMultiPartOnlyJson(method,content);
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(requestBody, header);
         return requestEntity;
     }
@@ -168,7 +168,7 @@ public class ImageStub extends TestUtils {
         return result;
     }
 
-    protected MultiValueMap<String, Object> createMultipartTwoFileAndJsonRequest(String content) throws IOException {
+    protected MultiValueMap<String, Object> createMultipartTwoFileAndJsonRequest(String method,String content) throws IOException {
         HttpEntity<ByteArrayResource> imageOne = getRealFileRequest();
         HttpEntity<ByteArrayResource> imageTwo = getRealFileRequest();
         HttpEntity<String> jsonRequest = super.getJsonRequestHeader(content);
@@ -177,14 +177,14 @@ public class ImageStub extends TestUtils {
 
         requestBody.add("imageList",imageOne);
         requestBody.add("imageList",imageTwo);
-        requestBody.add("post",jsonRequest);
+        requestBody.add(method,jsonRequest);
         return requestBody;
     }
-    protected MultiValueMap<String, Object> createMultiPartOnlyJson(String content) throws IOException {
+    protected MultiValueMap<String, Object> createMultiPartOnlyJson(String method,String content) throws IOException {
         HttpEntity<String> jsonRequest = super.getJsonRequestHeader(content);
 
         MultiValueMap<String, Object> requestBody = new LinkedMultiValueMap<>();
-        requestBody.add("post",jsonRequest);
+        requestBody.add(method,jsonRequest);
         return requestBody;
     }
 

--- a/BE/backend/src/test/java/project/main/webstore/totalTest/ItemControllerTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/totalTest/ItemControllerTest.java
@@ -2,12 +2,9 @@ package project.main.webstore.totalTest;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
-import java.net.URISyntaxException;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,23 +15,27 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
 import project.main.webstore.domain.item.dto.ItemIdResponseDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
-import project.main.webstore.domain.item.dto.ItemResponseDto;
 import project.main.webstore.domain.item.stub.ItemStub;
 import project.main.webstore.dto.ResponseDto;
+
 
 /*
  * DB에 저장 되어 있는 사용자 ID : 1L 클라이언트 2L 어드민   asdffcx1111
  * 상품 생성은 상품을 생성한 뒤 삭제하는 로직을 통해 구현한다.
  * 상품 수정 및 조회는 기존에 가지고 있는 데이터를 활용해서 구현한다.
- * 저장된 item 2L : 이미지를 가지고 있음, 3L : 이미지가 없음
- * item 2L 에 연결된 옵션들 : 옵션 1L, 옵션 2L
+ * 저장된 item 1L : 이미지를 가지고 있음, 2L : 이미지 있음  [2장]
+ * item 1L 에 연결된 옵션들 : 옵션 1L, 옵션 2L 옵션 3L
  **/
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureMockMvc
 public class ItemControllerTest {
 
+    @Container
+    static MySQLContainer mySQLContainer = new MySQLContainer("mysql:8");
     final String URL = "http://localhost:";
     final String DEFAULT_URL = "/api/items";
     TestRestTemplate clientLoginTest = new TestRestTemplate("client@gmail.com", "asdffcx1111");
@@ -47,13 +48,6 @@ public class ItemControllerTest {
     @LocalServerPort
     private int port;
 
-    @AfterEach
-    void after() {
-        String url = URL + port + DEFAULT_URL;
-        System.out.println("### DELETE RESULT ItemId = " + itemId);
-        adminLoginTest.delete(url, itemId);
-    }
-
     @Test
     @DisplayName("상품 등록 : 이미지 포함")
     void post_item_test() throws Exception {
@@ -61,7 +55,7 @@ public class ItemControllerTest {
         String content = gson.toJson(post);
 
         HttpEntity<MultiValueMap<String, Object>> requestEntity =
-                itemStub.getMultipartTwoImageAndJsonDataRequest(content);
+                itemStub.getMultipartTwoImageAndJsonDataRequest("post", content);
 
         String url = "http://localhost:" + port + "/api/items";
         System.out.println("url = " + url);
@@ -86,7 +80,7 @@ public class ItemControllerTest {
         String content = gson.toJson(post);
 
         HttpEntity<MultiValueMap<String, Object>> requestEntity =
-                itemStub.getMultipartJsonDataRequest(content);
+                itemStub.getMultipartJsonDataRequest("post", content);
 
         String url = "http://localhost:" + port + "/api/items";
         System.out.println("url = " + url);
@@ -104,40 +98,7 @@ public class ItemControllerTest {
         System.out.println("##### itemId = " + itemId);
     }
 
-    @Test
-    @DisplayName("상품 수정 : 이미지 없음")
-    void patch_item_no_image_test() throws Exception {
-        //상품 조회
 
-    }
-
-    private void requestItemGet() {
-        String url = "http://localhost:" + port + "/api/items/{itemId}";
-        ResponseEntity<String> getResponse = adminLoginTest.getForEntity(url, String.class, itemId);
-        Type responseType = new TypeToken<ResponseDto<ItemResponseDto>>() {
-        }.getType();
-        ResponseDto<ItemResponseDto> getResponseDto = gson.fromJson(getResponse.getBody(),
-                responseType);
-    }
-
-    private void requestItemPost()
-            throws IOException, URISyntaxException {
-        ItemPostDto post = itemStub.createPostDtoWithImage();
-        String content = gson.toJson(post);
-
-        HttpEntity<MultiValueMap<String, Object>> requestEntity =
-                itemStub.getMultipartTwoImageAndJsonDataRequest(content);
-
-        String url = "http://localhost:" + port + "/api/items";
-        System.out.println("url = " + url);
-        ResponseEntity<String> response = adminLoginTest.postForEntity(new URI(url),
-                requestEntity, String.class);
-        String body = response.getBody();
-        Type responseType = new TypeToken<ResponseDto<ItemIdResponseDto>>() {
-        }.getType();
-        ResponseDto<ItemIdResponseDto> responseDto = gson.fromJson(body, responseType);
-        itemId = responseDto.getData().getItemId();
-    }
 
 
 }

--- a/BE/backend/src/test/java/project/main/webstore/totalTest/ItemControllerTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/totalTest/ItemControllerTest.java
@@ -1,169 +1,100 @@
 package project.main.webstore.totalTest;
 
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.net.URI;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
-import org.springframework.http.*;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
-import project.main.webstore.annotation.WithMockCustomUser;
-import project.main.webstore.domain.image.dto.ImageSortPostDto;
-import project.main.webstore.domain.item.dto.ItemPatchDto;
+import project.main.webstore.domain.item.dto.ItemIdResponseDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
-import project.main.webstore.domain.item.dto.OptionPostRequestDto;
-import project.main.webstore.domain.item.enums.Category;
 import project.main.webstore.domain.item.stub.ItemStub;
-import project.main.webstore.domain.users.enums.UserRole;
-import project.main.webstore.security.dto.UserInfoDto;
-import project.main.webstore.security.jwt.utils.JwtTokenizer;
+import project.main.webstore.dto.ResponseDto;
 
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-
-
+/*
+* DB에 저장 되어 있는 사용자 ID : 1L 클라이언트 2L 어드민   asdffcx1111
+* 상품 조회 생성 등등의 시나리오는 모두 상품을 생성한 뒤 작업한 후 제거하는 방식으로 진행한다.
+**/
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureMockMvc
 public class ItemControllerTest {
+    final String URL = "http://localhost:";
+    TestRestTemplate clientLoginTest = new TestRestTemplate("client@gmail.com","asdffcx1111");
+    TestRestTemplate adminLoginTest = new TestRestTemplate("admin@gmail.com","asdffcx1111");
+    TestRestTemplate noLoginTest = new TestRestTemplate();
     final String DEFAULT_URL = "/api/items";
-    TestRestTemplate template = new TestRestTemplate();
-    @Autowired
-    Gson gson;
-    @Autowired
-    MockMvc mvc;
-    @Autowired
-    JwtTokenizer jwtTokenizer;
-    ItemStub itemStub = new ItemStub();
+    Long itemId;
     @LocalServerPort
     private int port;
 
+    @Autowired
+    Gson gson;
+    ItemStub itemStub = new ItemStub();
+
+    @AfterEach
+    void after() {
+        String url = URL + port + DEFAULT_URL;
+        System.out.println("### DELETE RESULT ItemId = " + itemId);
+        adminLoginTest.delete(url,itemId);
+    }
+
     @Test
-    @DisplayName("상품 등록")
-    @WithMockCustomUser
-    @Transactional
+    @DisplayName("상품 등록 : 이미지 포함")
     void post_item_test() throws Exception {
-        UserInfoDto userInfo = new UserInfoDto("2", "admin@gmailcom", "김복자", UserRole.ADMIN);
-        String accessToken = jwtTokenizer.delegateAccessToken(userInfo);
+        ItemPostDto post = itemStub.createPostDtoWithImage();
+        String content = gson.toJson(post);
 
-        ItemPostDto imagePostDto = ItemPostDto.builder()
-                .defaultCount(100)
-                .itemPrice(1000000)
-                .deliveryPrice(3000)
-                .category(Category.COMPUTER)
-                .discountRate(10)
-                .name("맥북")
-                .description("이것은 맥북입니다.")
-                .optionList(List.of(new OptionPostRequestDto("옵션 세부 내역", 100, 10000, "옵션 이름"), new OptionPostRequestDto("옵션 세부 내역", 100, 10000, "옵션 이름")))
-                .infoList(List.of(new ImageSortPostDto(1, true)))
-                .build();
-        String content = gson.toJson(imagePostDto);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
-        headers.setBearerAuth(accessToken);
-        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-
-        Resource resource = new ClassPathResource("image/testImage.png");
-
-        ByteArrayResource bytes = new ByteArrayResource(resource.getInputStream().readAllBytes()) {
-            public String getFilename() {
-                return "image.png";
-            }
-        };
-
-
-        HttpHeaders partHeaders = new HttpHeaders();
-        partHeaders.setContentType(MediaType.IMAGE_PNG);
-        HttpEntity<ByteArrayResource> bytesPart = new HttpEntity<>(bytes, partHeaders);
-
-        HttpHeaders partHeaders2 = new HttpHeaders();
-        partHeaders2.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<String> post2 = new HttpEntity<>(content, partHeaders2);
-
-        body.add("post", post2);
-        body.add("image", bytesPart);
-
-        HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-
+        HttpEntity<MultiValueMap<String, Object>> requestEntity =
+                                itemStub.getMultipartTwoImageAndJsonDataRequest(content);
 
         String url = "http://localhost:" + port + "/api/items";
-        ResponseEntity<String> responseEntity = template.postForEntity(new URI(url), requestEntity, String.class);
-        String body1 = responseEntity.getBody();
-        System.out.println(body1);
-    }
+        System.out.println("url = " + url);
+        ResponseEntity<String> response = adminLoginTest.postForEntity(new URI(url),
+                requestEntity, String.class);
+        String body = response.getBody();
+        Type responseType = new TypeToken<ResponseDto<ItemIdResponseDto>>() {}.getType();
+        ResponseDto<ItemIdResponseDto> responseDto = gson.fromJson(body, responseType);
+         itemId = responseDto.getData().getItemId();
 
+        Assertions.assertThat(responseDto.getCode()).isEqualTo("C201");
+        Assertions.assertThat(responseDto.getMessage()).isEqualTo("생성 완료");
+        Assertions.assertThat(responseDto.getData().getItemId()).isNotNull();
+        System.out.println("##### itemId = " + itemId);
+    }
     @Test
-    @DisplayName("수정 [이미지 없음] :성공")
-    @WithMockCustomUser
-    void patch_no_image_test() throws Exception {
-        // given
-        ItemPatchDto patch = itemStub.createPatchNoImage();
-        String content = gson.toJson(patch);
-        MockMultipartFile patchItem = new MockMultipartFile("patch", "patch", "application/json", content.getBytes(StandardCharsets.UTF_8));
-        // when
-        ResultActions perform = mvc.perform(MockMvcRequestBuilders.multipart(HttpMethod.PATCH, DEFAULT_URL + "/{itemId}", 1L).file(patchItem).accept(MediaType.APPLICATION_JSON));
-        // then
-        perform
-                .andDo(MockMvcResultHandlers.log())
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.itemId").value(1L))
-                .andExpect(MockMvcResultMatchers.header().string("Location", "/api/items/1"));
-    }
+    @DisplayName("상품 등록 : 이미지 없음")
+    void post_item_no_image_test() throws Exception {
+        ItemPostDto post = itemStub.createPostDtoNoImage();
+        String content = gson.toJson(post);
 
-    @Test
-    @DisplayName("수정 :성공")
-    @WithMockCustomUser
-    void patch_image_test() throws Exception {
-        // given
-        ItemPatchDto patch = itemStub.createPatchWithImageTwo();
-        String content = gson.toJson(patch);
-        MockMultipartFile patchItem = new MockMultipartFile("patch", "patch", "application/json", content.getBytes(StandardCharsets.UTF_8));
+        HttpEntity<MultiValueMap<String, Object>> requestEntity =
+                                itemStub.getMultipartJsonDataRequest(content);
 
+        String url = "http://localhost:" + port + "/api/items";
+        System.out.println("url = " + url);
+        ResponseEntity<String> response = adminLoginTest.postForEntity(new URI(url),
+                requestEntity, String.class);
+        String body = response.getBody();
+        Type responseType = new TypeToken<ResponseDto<ItemIdResponseDto>>() {}.getType();
+        ResponseDto<ItemIdResponseDto> responseDto = gson.fromJson(body, responseType);
+         itemId = responseDto.getData().getItemId();
 
-        Resource resource = new ClassPathResource("image/testImage.png");
-        MockMultipartFile file1 = new MockMultipartFile("imageList", "originalFile.png", "png", resource.getInputStream());
-
-        // when
-        ResultActions perform = mvc.perform(MockMvcRequestBuilders.multipart(HttpMethod.PATCH, DEFAULT_URL + "/{itemId}", 1L).file(file1).file(file1).file(patchItem).accept(MediaType.APPLICATION_JSON));
-        // then
-        perform
-                .andDo(MockMvcResultHandlers.log())
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.itemId").value(1L))
-                .andExpect(MockMvcResultMatchers.header().string("Location", "/api/items/1"));
+        Assertions.assertThat(responseDto.getCode()).isEqualTo("C201");
+        Assertions.assertThat(responseDto.getMessage()).isEqualTo("생성 완료");
+        Assertions.assertThat(responseDto.getData().getItemId()).isNotNull();
+        System.out.println("##### itemId = " + itemId);
     }
 
 
-    @Test
-    @DisplayName("상품 삭제")
-    @WithMockCustomUser
-    void delete_image_test() throws Exception{
-        // given
-
-        // when
-        ResultActions perform = mvc.perform(MockMvcRequestBuilders.delete(DEFAULT_URL + "/{item-Id}", 1L));
-        // then
-        perform
-                .andDo(MockMvcResultHandlers.log())
-                .andExpect(MockMvcResultMatchers.status().isNoContent());
-    }
 
 }

--- a/BE/backend/src/test/java/project/main/webstore/totalTest/ItemControllerTest.java
+++ b/BE/backend/src/test/java/project/main/webstore/totalTest/ItemControllerTest.java
@@ -2,8 +2,10 @@ package project.main.webstore.totalTest;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.net.URISyntaxException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,34 +20,38 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 import project.main.webstore.domain.item.dto.ItemIdResponseDto;
 import project.main.webstore.domain.item.dto.ItemPostDto;
+import project.main.webstore.domain.item.dto.ItemResponseDto;
 import project.main.webstore.domain.item.stub.ItemStub;
 import project.main.webstore.dto.ResponseDto;
 
 /*
-* DB에 저장 되어 있는 사용자 ID : 1L 클라이언트 2L 어드민   asdffcx1111
-* 상품 조회 생성 등등의 시나리오는 모두 상품을 생성한 뒤 작업한 후 제거하는 방식으로 진행한다.
-**/
+ * DB에 저장 되어 있는 사용자 ID : 1L 클라이언트 2L 어드민   asdffcx1111
+ * 상품 생성은 상품을 생성한 뒤 삭제하는 로직을 통해 구현한다.
+ * 상품 수정 및 조회는 기존에 가지고 있는 데이터를 활용해서 구현한다.
+ * 저장된 item 2L : 이미지를 가지고 있음, 3L : 이미지가 없음
+ * item 2L 에 연결된 옵션들 : 옵션 1L, 옵션 2L
+ **/
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @AutoConfigureMockMvc
 public class ItemControllerTest {
-    final String URL = "http://localhost:";
-    TestRestTemplate clientLoginTest = new TestRestTemplate("client@gmail.com","asdffcx1111");
-    TestRestTemplate adminLoginTest = new TestRestTemplate("admin@gmail.com","asdffcx1111");
-    TestRestTemplate noLoginTest = new TestRestTemplate();
-    final String DEFAULT_URL = "/api/items";
-    Long itemId;
-    @LocalServerPort
-    private int port;
 
+    final String URL = "http://localhost:";
+    final String DEFAULT_URL = "/api/items";
+    TestRestTemplate clientLoginTest = new TestRestTemplate("client@gmail.com", "asdffcx1111");
+    TestRestTemplate adminLoginTest = new TestRestTemplate("admin@gmail.com", "asdffcx1111");
+    TestRestTemplate noLoginTest = new TestRestTemplate();
+    Long itemId;
     @Autowired
     Gson gson;
     ItemStub itemStub = new ItemStub();
+    @LocalServerPort
+    private int port;
 
     @AfterEach
     void after() {
         String url = URL + port + DEFAULT_URL;
         System.out.println("### DELETE RESULT ItemId = " + itemId);
-        adminLoginTest.delete(url,itemId);
+        adminLoginTest.delete(url, itemId);
     }
 
     @Test
@@ -55,22 +61,24 @@ public class ItemControllerTest {
         String content = gson.toJson(post);
 
         HttpEntity<MultiValueMap<String, Object>> requestEntity =
-                                itemStub.getMultipartTwoImageAndJsonDataRequest(content);
+                itemStub.getMultipartTwoImageAndJsonDataRequest(content);
 
         String url = "http://localhost:" + port + "/api/items";
         System.out.println("url = " + url);
         ResponseEntity<String> response = adminLoginTest.postForEntity(new URI(url),
                 requestEntity, String.class);
         String body = response.getBody();
-        Type responseType = new TypeToken<ResponseDto<ItemIdResponseDto>>() {}.getType();
+        Type responseType = new TypeToken<ResponseDto<ItemIdResponseDto>>() {
+        }.getType();
         ResponseDto<ItemIdResponseDto> responseDto = gson.fromJson(body, responseType);
-         itemId = responseDto.getData().getItemId();
+        itemId = responseDto.getData().getItemId();
 
         Assertions.assertThat(responseDto.getCode()).isEqualTo("C201");
         Assertions.assertThat(responseDto.getMessage()).isEqualTo("생성 완료");
         Assertions.assertThat(responseDto.getData().getItemId()).isNotNull();
         System.out.println("##### itemId = " + itemId);
     }
+
     @Test
     @DisplayName("상품 등록 : 이미지 없음")
     void post_item_no_image_test() throws Exception {
@@ -78,16 +86,17 @@ public class ItemControllerTest {
         String content = gson.toJson(post);
 
         HttpEntity<MultiValueMap<String, Object>> requestEntity =
-                                itemStub.getMultipartJsonDataRequest(content);
+                itemStub.getMultipartJsonDataRequest(content);
 
         String url = "http://localhost:" + port + "/api/items";
         System.out.println("url = " + url);
         ResponseEntity<String> response = adminLoginTest.postForEntity(new URI(url),
                 requestEntity, String.class);
         String body = response.getBody();
-        Type responseType = new TypeToken<ResponseDto<ItemIdResponseDto>>() {}.getType();
+        Type responseType = new TypeToken<ResponseDto<ItemIdResponseDto>>() {
+        }.getType();
         ResponseDto<ItemIdResponseDto> responseDto = gson.fromJson(body, responseType);
-         itemId = responseDto.getData().getItemId();
+        itemId = responseDto.getData().getItemId();
 
         Assertions.assertThat(responseDto.getCode()).isEqualTo("C201");
         Assertions.assertThat(responseDto.getMessage()).isEqualTo("생성 완료");
@@ -95,6 +104,40 @@ public class ItemControllerTest {
         System.out.println("##### itemId = " + itemId);
     }
 
+    @Test
+    @DisplayName("상품 수정 : 이미지 없음")
+    void patch_item_no_image_test() throws Exception {
+        //상품 조회
+
+    }
+
+    private void requestItemGet() {
+        String url = "http://localhost:" + port + "/api/items/{itemId}";
+        ResponseEntity<String> getResponse = adminLoginTest.getForEntity(url, String.class, itemId);
+        Type responseType = new TypeToken<ResponseDto<ItemResponseDto>>() {
+        }.getType();
+        ResponseDto<ItemResponseDto> getResponseDto = gson.fromJson(getResponse.getBody(),
+                responseType);
+    }
+
+    private void requestItemPost()
+            throws IOException, URISyntaxException {
+        ItemPostDto post = itemStub.createPostDtoWithImage();
+        String content = gson.toJson(post);
+
+        HttpEntity<MultiValueMap<String, Object>> requestEntity =
+                itemStub.getMultipartTwoImageAndJsonDataRequest(content);
+
+        String url = "http://localhost:" + port + "/api/items";
+        System.out.println("url = " + url);
+        ResponseEntity<String> response = adminLoginTest.postForEntity(new URI(url),
+                requestEntity, String.class);
+        String body = response.getBody();
+        Type responseType = new TypeToken<ResponseDto<ItemIdResponseDto>>() {
+        }.getType();
+        ResponseDto<ItemIdResponseDto> responseDto = gson.fromJson(body, responseType);
+        itemId = responseDto.getData().getItemId();
+    }
 
 
 }

--- a/BE/backend/src/test/resources/application.yml
+++ b/BE/backend/src/test/resources/application.yml
@@ -1,14 +1,14 @@
 
 spring:
   datasource:
-    url: ${DATABASE_TEST}
-    password: ${DATABASE_PASSWORD}
-    username: ${DATABASE_ID}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8://test
+    username: test_user
+    password: 1234
   jpa:
     database-platform: org.hibernate.dialect.MySQL55Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         highlight_sql: true
@@ -34,6 +34,10 @@ spring:
             scope:
               - email
               - profile
+  sql:
+    init:
+      data-locations: classpath:data/data.sql
+      schema-locations: classpath:data/schema.sql
 logging:
   level:
     org.hibernate.sql: info
@@ -62,6 +66,8 @@ springdoc:
 iamport:
   api-key: ${IAMPORT_API_KEY}
   secret-key: ${SECRET_KEY}
+  merchant_uid: ${MERCHANT_UID}
+
 
 mail:
   address:

--- a/BE/backend/src/test/resources/application.yml
+++ b/BE/backend/src/test/resources/application.yml
@@ -8,7 +8,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL55Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         highlight_sql: true
@@ -38,6 +38,7 @@ spring:
     init:
       data-locations: classpath:data/data.sql
       schema-locations: classpath:data/schema.sql
+      mode: always
 logging:
   level:
     org.hibernate.sql: info

--- a/BE/backend/src/test/resources/data/data.sql
+++ b/BE/backend/src/test/resources/data/data.sql
@@ -1,0 +1,248 @@
+-- 사용자 등록 admin 계정 1개 client 계정 1개
+insert into  cart
+(created_date, last_modified_date)
+values
+    (now(), now());
+insert into users
+(created_date, last_modified_date, cart_id, email, grade, last_connected_date, nick_name, password, phone, profile_image, provider_id, user_name, user_role, user_status)
+values
+    (now(),now(),1,'client@gmail.com','NORMAL',now(),'김클라','{bcrypt}$2a$10$UMwSaoJW2v9aC4QAF8HqpOOEiVcU12jLNJrZSakG3PKVIXWNSG/v.','010-1234-1234','https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSz7rUlbKGMcXKcNkWGw6CnN_CRBz1hYjrsKXFVio9s26u7nQEILnX8EGV8e5UEIdGdsI0&usqp=CAU','JWT','김송모','CLIENT','TMP');
+
+insert into  cart
+(created_date, last_modified_date)
+values
+    (now(), now());
+insert into users
+(created_date, last_modified_date, cart_id, email, grade, last_connected_date, nick_name, password, phone, profile_image, provider_id, user_name, user_role, user_status)
+values
+    (now(),now(),2,'admin@gmail.com','NORMAL',now(),'김어드','{bcrypt}$2a$10$UMwSaoJW2v9aC4QAF8HqpOOEiVcU12jLNJrZSakG3PKVIXWNSG/v.','010-1234-1234','https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSz7rUlbKGMcXKcNkWGw6CnN_CRBz1hYjrsKXFVio9s26u7nQEILnX8EGV8e5UEIdGdsI0&usqp=CAU','JWT','김송모','ADMIN','TMP');
+-- 상품 등록 2개 각 상품은 옵션 2개 이미지 2개 보유
+
+insert
+into
+    item_option
+(additional_price, default_option, item_id, item_count, option_detail, option_name)
+values
+    (0, true, null, 1000, null, null);
+
+
+    insert
+    into
+        item
+        (created_date, last_modified_date, category, default_item_item_option_id, delivery_price, description, discount_rate, item_name, item_price, item_status, sales_quantity, view_count)
+    values
+        (now(), now(), 'COMPUTER', 1, 3000, '상품에 대한 상세 설명 1', 0, '맥북 1', 1000000, 'ON_STACK', 0, 0);
+
+    insert
+    into
+        image
+        (created_date, last_modified_date, ext, hash, image_order, image_path, is_representative, original_name, thumbnail_path, upload_name, item_id, category)
+    values
+        (now(), now(), '.png', 'aabacd36781f70c6a844bf07835299d2', 0, 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSz7rUlbKGMcXKcNkWGw6CnN_CRBz1hYjrsKXFVio9s26u7nQEILnX8EGV8e5UEIdGdsI0&usqp=CAU', false, '스크린샷', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSz7rUlbKGMcXKcNkWGw6CnN_CRBz1hYjrsKXFVio9s26u7nQEILnX8EGV8e5UEIdGdsI0&usqp=CAU', 'random001', 1, 'ITEM');
+
+insert
+into
+    image
+(created_date, last_modified_date, ext, hash, image_order, image_path, is_representative, original_name, thumbnail_path, upload_name, item_id, category)
+values
+    (now(), now(), '.png', 'aabacd36781f70c6a844bf07835299d2', 1, 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSz7rUlbKGMcXKcNkWGw6CnN_CRBz1hYjrsKXFVio9s26u7nQEILnX8EGV8e5UEIdGdsI0&usqp=CAU', true, '스크린샷', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSz7rUlbKGMcXKcNkWGw6CnN_CRBz1hYjrsKXFVio9s26u7nQEILnX8EGV8e5UEIdGdsI0&usqp=CAU', 'random001', 1, 'ITEM');
+
+
+    insert
+    into
+        item_option
+        (additional_price, default_option, item_id, item_count, option_detail, option_name)
+    values
+        (10000, false, 1, 100, '상품 상세 정보 1', null);
+insert
+into
+    item_option
+(additional_price, default_option, item_id, item_count, option_detail, option_name)
+values
+    (20000, false, 1, 200, '상품 상세 정보 2', null);
+
+update
+    item_option
+set
+    additional_price=0,
+    default_option=true,
+    item_id=1,
+    item_count=1000,
+    option_detail=null,
+    option_name=null
+where
+        item_option_id=1;
+
+-- 경계점
+insert
+into
+    item_option
+(additional_price, default_option, item_id, item_count, option_detail, option_name)
+values
+    (0, true, null, 1000, null, null);
+
+    insert
+    into
+        item
+        (created_date, last_modified_date, category, default_item_item_option_id, delivery_price, description, discount_rate, item_name, item_price, item_status, sales_quantity, view_count)
+    values
+        (now(), now(), 'COMPUTER', 4, 3000, '상품에 대한 상세 설명 1', 0, '맥북 1', 1000000, 'ON_STACK', 0, 0);
+
+    insert
+    into
+        image
+        (created_date, last_modified_date, ext, hash, image_order, image_path, is_representative, original_name, thumbnail_path, upload_name, item_id, category)
+    values
+        (now(), now(), '.png', 'aabacd36781f70c6a844bf07835299d2', 0, 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSz7rUlbKGMcXKcNkWGw6CnN_CRBz1hYjrsKXFVio9s26u7nQEILnX8EGV8e5UEIdGdsI0&usqp=CAU', false, '스크린샷', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSz7rUlbKGMcXKcNkWGw6CnN_CRBz1hYjrsKXFVio9s26u7nQEILnX8EGV8e5UEIdGdsI0&usqp=CAU', 'random0011', 2, 'ITEM');
+
+insert
+into
+    image
+(created_date, last_modified_date, ext, hash, image_order, image_path, is_representative, original_name, thumbnail_path, upload_name, item_id, category)
+values
+    (now(), now(), '.png', 'aabacd36781f70c6a844bf07835299d2', 1, 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSz7rUlbKGMcXKcNkWGw6CnN_CRBz1hYjrsKXFVio9s26u7nQEILnX8EGV8e5UEIdGdsI0&usqp=CAU', true, '스크린샷', 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSz7rUlbKGMcXKcNkWGw6CnN_CRBz1hYjrsKXFVio9s26u7nQEILnX8EGV8e5UEIdGdsI0&usqp=CAU', 'random0022', 2, 'ITEM');
+
+
+    insert
+    into
+        item_option
+        (additional_price, default_option, item_id, item_count, option_detail, option_name)
+    values
+        (10000, false, 2, 100, '상품 상세 정보 1', null);
+insert
+into
+    item_option
+(additional_price, default_option, item_id, item_count, option_detail, option_name)
+values
+    (20000, false, 2, 200, '상품 상세 정보 2', null);
+
+update
+    item_option
+set
+    additional_price=0,
+    default_option=true,
+    item_id=2,
+    item_count=1000,
+    option_detail=null,
+    option_name=null
+where
+        item_option_id=4;
+
+--  리뷰 2개
+insert
+into
+    review
+(created_date, last_modified_date, best, comment, item_id, rating, user_id,id)
+values
+    (now(), now(), false, '상품 리뷰 본문1', 1, 10, 1,1);
+insert
+into
+    review
+(created_date, last_modified_date, best, comment, item_id, rating, user_id,id)
+values
+    (now(), now(), false, '상품 리뷰 본문2', 1, 10, 1,2);
+insert
+into
+    review
+(created_date, last_modified_date, best, comment, item_id, rating, user_id,id)
+values
+    (now(), now(), false, '상품 리뷰 본문3', 2, 10, 1,3);
+insert
+into
+    review
+(created_date, last_modified_date, best, comment, item_id, rating, user_id,id)
+values
+    (now(), now(), false, '상품 리뷰 본문4', 2, 10, 1,4);
+
+-- QNA 2개
+insert
+into
+    question
+(created_date, last_modified_date, answer_id, comment, item_id, qna_status, user_id)
+values
+    (now(), now(), null, '질문 본문1', 1, 'REGISTER', 1);
+
+insert
+into
+    question
+(created_date, last_modified_date, answer_id, comment, item_id, qna_status, user_id)
+values
+    (now(), now(), null, '질문 본문2', 1, 'REGISTER', 1);
+insert
+into
+    question
+(created_date, last_modified_date, answer_id, comment, item_id, qna_status, user_id)
+values
+    (now(), now(), null, '질문 본문3', 2, 'REGISTER', 1);
+insert
+into
+    question
+(created_date, last_modified_date, answer_id, comment, item_id, qna_status, user_id)
+values
+    (now(), now(), null, '질문 본문4', 2, 'REGISTER', 1);
+
+insert
+into
+    answer
+(created_date, last_modified_date, comment, qna_status, user_id)
+values
+    (now(), now(), '답변 본문 1', 'ANSWER_COMPLETE', 2);
+update
+    question
+set
+    last_modified_date=now(),
+    answer_id=1,
+    comment='질문 본문1',
+    item_id=1,
+    qna_status='ANSWER_COMPLETE',
+    user_id=1
+where
+        id=1;
+
+insert
+into
+    answer
+(created_date, last_modified_date, comment, qna_status, user_id)
+values
+    (now(), now(), '답변 본문 2', 'ANSWER_COMPLETE', 2);
+update
+    question
+set
+    last_modified_date=now(),
+    answer_id=2,
+    comment='질문 본문2',
+    item_id=2,
+    qna_status='ANSWER_COMPLETE',
+    user_id=1
+where
+        id=3;
+
+-- Notice 2개
+insert
+into
+    notice
+(created_date, last_modified_date, content, notice_category, title, user_id, view_count)
+values
+    (now(), now(), '공지 본문 1', 'EVENT', '공지 제목 1', 2, 0);
+
+insert
+into
+    image
+(created_date, last_modified_date, ext, hash, image_order, image_path, is_representative, original_name, thumbnail_path, upload_name, notice_id, category)
+values
+    (now(), now(), '.png', 'f239r0f3f3223fr', 0, '이미지 파일 경로', true, '이미지파일', '섬네일 경로', 'f23434f', 1, 'NOTICE');
+insert
+into
+    notice
+(created_date, last_modified_date, content, notice_category, title, user_id, view_count)
+values
+    (now(), now(), '공지 본문 2', 'EVENT', '공지 제목 2', 2, 0);
+
+insert
+into
+    image
+(created_date, last_modified_date, ext, hash, image_order, image_path, is_representative, original_name, thumbnail_path, upload_name, notice_id, category)
+values
+    (now(), now(), '.png', 'f239r0f3f3223fr', 0, '이미지 파일 경로2', true, '이미지파일2', '섬네일 경로2', 'f23434f', 2, 'NOTICE');
+
+

--- a/BE/backend/src/test/resources/data/schema.sql
+++ b/BE/backend/src/test/resources/data/schema.sql
@@ -1,0 +1,289 @@
+create table banner
+(
+    id         bigint auto_increment
+        primary key,
+    image_path varchar(255) null
+);
+
+create table cart
+(
+    id                 bigint auto_increment
+        primary key,
+    created_date       datetime null,
+    last_modified_date datetime null
+);
+
+create table hibernate_sequence
+(
+    next_val bigint null
+);
+
+create table item
+(
+    item_id                     bigint auto_increment
+        primary key,
+    created_date                datetime     null,
+    last_modified_date          datetime     null,
+    category                    varchar(255) null,
+    delivery_price              int          not null,
+    description                 longtext     null,
+    discount_rate               int          null,
+    item_name                   varchar(255) not null,
+    item_price                  int          not null,
+    item_status                 varchar(255) null,
+    sales_quantity              int          not null,
+    view_count                  bigint       not null,
+    default_item_item_option_id bigint       null
+);
+
+create table item_option
+(
+    item_option_id   bigint auto_increment
+        primary key,
+    additional_price int          null,
+    default_option   bit          not null,
+    item_count       int          null,
+    option_detail    varchar(255) null,
+    option_name      varchar(255) null,
+    item_id          bigint       null,
+    constraint FKpiufbijq6m8l18jf9a0nwny62
+        foreign key (item_id) references item (item_id)
+);
+
+create table cart_item
+(
+    id         bigint auto_increment
+        primary key,
+    item_count int    null,
+    cart_id    bigint null,
+    option_id  bigint null,
+    constraint FK1s49ifsqr8e44s4tgiqr8jw3d
+        foreign key (option_id) references item_option (item_option_id),
+    constraint FK1uobyhgl1wvgt1jpccia8xxs3
+        foreign key (cart_id) references cart (id)
+);
+
+alter table item
+    add constraint FKt438u63no05r6lhomj0fvueyb
+        foreign key (default_item_item_option_id) references item_option (item_option_id);
+
+create table item_cart_item_list
+(
+    item_item_id      bigint not null,
+    cart_item_list_id bigint not null,
+    constraint UK_p4mcoejdg90wnxkn8y1w15c0c
+        unique (cart_item_list_id),
+    constraint FK4ma8ktu6nxbasbp5w9sijrown
+        foreign key (item_item_id) references item (item_id),
+    constraint FKdtyf6d0g77oawx3qvh1mqb2pm
+        foreign key (cart_item_list_id) references cart_item (id)
+);
+
+create table tag
+(
+    id   bigint auto_increment
+        primary key,
+    name varchar(255) null
+);
+
+create table users
+(
+    id                  bigint auto_increment
+        primary key,
+    created_date        datetime     null,
+    last_modified_date  datetime     null,
+    email               varchar(255) null,
+    grade               varchar(255) null,
+    last_connected_date datetime     null,
+    nick_name           varchar(255) null,
+    password            varchar(255) null,
+    phone               varchar(255) null,
+    profile_image       varchar(255) null,
+    provider_id         varchar(255) null,
+    user_name           varchar(255) null,
+    user_role           varchar(255) null,
+    user_status         varchar(255) null,
+    cart_id             bigint       null,
+    constraint FKqmifheg6lnigfifvlmpjnuny8
+        foreign key (cart_id) references cart (id)
+);
+
+create table answer
+(
+    id                 bigint auto_increment
+        primary key,
+    created_date       datetime     null,
+    last_modified_date datetime     null,
+    comment            longtext     null,
+    qna_status         varchar(255) null,
+    user_id            bigint       null,
+    constraint FKsdj8jab9t00diflkysw22k7bv
+        foreign key (user_id) references users (id)
+);
+
+create table notice
+(
+    id                 bigint auto_increment
+        primary key,
+    created_date       datetime     null,
+    last_modified_date datetime     null,
+    content            longtext     null,
+    notice_category    varchar(255) null,
+    title              varchar(255) null,
+    view_count         bigint       not null,
+    user_id            bigint       null,
+    constraint FK6hu3mfrsmpbqjk44w2fq5t5us
+        foreign key (user_id) references users (id)
+);
+
+create table orders
+(
+    order_id           bigint auto_increment
+        primary key,
+    created_date       datetime     null,
+    last_modified_date datetime     null,
+    address_detail     varchar(255) null,
+    address_simple     varchar(255) null,
+    phone              varchar(255) null,
+    zip_code           varchar(255) null,
+    delivery_company   varchar(255) null,
+    delivery_date      date         null,
+    delivery_price     int          not null,
+    message            varchar(255) null,
+    order_number       varchar(255) null,
+    orders_status      varchar(255) null,
+    recipient          varchar(255) null,
+    tracking_number    varchar(255) null,
+    user_id            bigint       null,
+    constraint FK32ql8ubntj5uh44ph9659tiih
+        foreign key (user_id) references users (id)
+);
+
+create table ordered_item
+(
+    id                 bigint auto_increment
+        primary key,
+    created_date       datetime     null,
+    last_modified_date datetime     null,
+    discount_rate      int          not null,
+    discounted_price   int          not null,
+    item_count         int          not null,
+    item_details       varchar(255) null,
+    option_details     varchar(255) null,
+    price              int          not null,
+    item_item_id       bigint       null,
+    item_option_id     bigint       null,
+    order_id           bigint       null,
+    constraint FK51dj38kcdahtjcx8h2be767sr
+        foreign key (order_id) references orders (order_id),
+    constraint FK75bf4yr0aurqjj6tw30l24grw
+        foreign key (item_item_id) references item (item_id),
+    constraint FKhckgj4xm76hs7vgu1c39fb1iq
+        foreign key (item_option_id) references item_option (item_option_id)
+);
+
+create table picked_item
+(
+    picked_id bigint auto_increment
+        primary key,
+    item_id   bigint null,
+    user_id   bigint null,
+    constraint FK412aa36e782r9cwskhp07b12a
+        foreign key (user_id) references users (id),
+    constraint FKprhy3ousui85b0gs84e7qt6t2
+        foreign key (item_id) references item (item_id)
+);
+
+create table question
+(
+    id                 bigint auto_increment
+        primary key,
+    created_date       datetime     null,
+    last_modified_date datetime     null,
+    comment            longtext     null,
+    qna_status         varchar(255) null,
+    answer_id          bigint       null,
+    item_id            bigint       null,
+    user_id            bigint       null,
+    constraint FK2w9qd6mx9oh2vchntaokhlj4f
+        foreign key (answer_id) references answer (id),
+    constraint FK7rnpup7eaonh2ubt922ormoij
+        foreign key (user_id) references users (id),
+    constraint FKjramekl8wg1qjhqixc509iwlq
+        foreign key (item_id) references item (item_id)
+);
+
+create table review
+(
+    id                 bigint       not null
+        primary key,
+    created_date       datetime     null,
+    last_modified_date datetime     null,
+    best               bit          not null,
+    comment            varchar(255) null,
+    rating             int          null,
+    item_id            bigint       null,
+    user_id            bigint       null,
+    constraint FK6cpw2nlklblpvc7hyt7ko6v3e
+        foreign key (user_id) references users (id),
+    constraint FK6hb6qqehnsm7mvfgv37m66hd7
+        foreign key (item_id) references item (item_id)
+);
+
+create table image
+(
+    category           varchar(31)  not null,
+    id                 bigint auto_increment
+        primary key,
+    created_date       datetime     null,
+    last_modified_date datetime     null,
+    ext                varchar(255) null,
+    hash               varchar(255) null,
+    image_order        int          not null,
+    image_path         varchar(255) null,
+    is_representative  bit          not null,
+    original_name      varchar(255) null,
+    thumbnail_path     varchar(255) null,
+    upload_name        varchar(255) null,
+    item_id            bigint       null,
+    notice_id          bigint       null,
+    review_id          bigint       null,
+    constraint FK2fyo6jg4fpq9108cbi16v37ft
+        foreign key (review_id) references review (id),
+    constraint FKmxefv2q9erynjpr2u4tftmn1r
+        foreign key (notice_id) references notice (id),
+    constraint FKscew1f5bnpn1nuaokhjg89u58
+        foreign key (item_id) references item (item_id)
+);
+
+create table likes
+(
+    id                 bigint auto_increment
+        primary key,
+    created_date       datetime null,
+    last_modified_date datetime null,
+    review_id          bigint   null,
+    user_id            bigint   null,
+    constraint FK65pxk1tcl3qtbvlcrjyitq865
+        foreign key (review_id) references review (id),
+    constraint FKnvx9seeqqyy71bij291pwiwrg
+        foreign key (user_id) references users (id)
+);
+
+create table shipping_info
+(
+    shipping_info  bigint auto_increment
+        primary key,
+    address_detail varchar(255) null,
+    address_simple varchar(255) null,
+    phone          varchar(255) null,
+    zip_code       varchar(255) null,
+    recipient      varchar(255) null,
+    order_id       bigint       null,
+    user_id        bigint       null,
+    constraint FK45idk6acnnfditxgyyk613m6r
+        foreign key (order_id) references orders (order_id),
+    constraint FKokw6bplftwitsoh1utl05eyk8
+        foreign key (user_id) references users (id)
+);
+

--- a/BE/backend/src/test/resources/logback-test.xml
+++ b/BE/backend/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+  <appender class="ch.qos.logback.core.ConsoleAppender" name="STDOUT">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger level="INFO" name="org.testcontainers"/>
+
+  <logger level="INFO" name="tc"/>
+  <logger level="WARN" name="com.github.dockerjava"/>
+  <logger level="OFF" name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire"/>
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>


### PR DESCRIPTION
# 작업 내용
1. Item 도메인 Mapper 수정
    - 엔티티에서 특정 dto별 생성자 생성이 아닌 일괄적인 생성자 사용, 변환의 모든 부분을 Mapper에서 구현
2. Item 도메인 테스트 구현
    - 단위 테스트를 통한 각 모듈의 신뢰성 구현
    - 통합 테스트 구현
        - 통합 테스트 시 RestTemplate의 사용을 통한 실제 요청과 유사한 테스트 환경 구축
3. TestContainer 구축을 통한 작업 환경 통일